### PR TITLE
MM-61109 fixed Error accessing board with added channels

### DIFF
--- a/server/services/store/sqlstore/board.go
+++ b/server/services/store/sqlstore/board.go
@@ -573,7 +573,6 @@ func (s *SQLStore) getMemberForBoard(db sq.BaseRunner, boardID, userID string) (
 	}
 
 	if len(members) == 0 {
-
 		if userID == model.SystemUserID {
 			return nil, model.NewErrNotFound(userID)
 		}


### PR DESCRIPTION
#### Summary
There was an issue with boards where users in a channel couldn't access boards, even if the channel had the required permissions. This was because boards only checked for board membership and didn’t account for channel membership(This was done using `mattermostAuthLayer` previously which was removed and in refactoring we lost this code: https://github.com/mattermost-community/focalboard/blob/de5e5cc4141f14f69bf0e5666383997b81f851d6/server/services/store/mattermostauthlayer/mattermostauthlayer.go#L978). I added code to ensure that if a user is in a channel with access to boards, they can successfully access it.

Steps to Reproduce:

- Join Channel A, which has access to a board in version 8.0.0.
- As a member of Channel A, confirm you can access the board.
- Upgrade the board to version 9.0.0.
- Notice that you can no longer access the board.

Reason:
- In the refactoring process for v9.0.0 (which removed standalone and single-user desktop code to make the boards plugin-only), the check for channel membership access was removed, resulting in access issues for channel members.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61109
