### PR TITLE
MM-61822 Fix the boards LHS and channel RHS boards channel memeber permission issue. 

### DIFF
--- a/server/services/store/sqlstore/board.go
+++ b/server/services/store/sqlstore/board.go
@@ -642,6 +642,29 @@ func (s *SQLStore) getMemberForBoard(db sq.BaseRunner, boardID, userID string) (
 	return members[0], nil
 }
 
+func (s *SQLStore) implicitBoardMembershipsFromRows(rows *sql.Rows) ([]*model.BoardMember, error) {
+	boardMembers := []*model.BoardMember{}
+
+	for rows.Next() {
+		var boardMember model.BoardMember
+
+		err := rows.Scan(
+			&boardMember.UserID,
+			&boardMember.BoardID,
+		)
+		if err != nil {
+			return nil, err
+		}
+		boardMember.Roles = "editor"
+		boardMember.SchemeEditor = true
+		boardMember.Synthetic = true
+
+		boardMembers = append(boardMembers, &boardMember)
+	}
+
+	return boardMembers, nil
+}
+
 func (s *SQLStore) getMembersForUser(db sq.BaseRunner, userID string) ([]*model.BoardMember, error) {
 	query := s.getQueryBuilder(db).
 		Select(boardMemberFields...).
@@ -649,16 +672,56 @@ func (s *SQLStore) getMembersForUser(db sq.BaseRunner, userID string) ([]*model.
 		LeftJoin(s.tablePrefix + "boards AS B ON B.id=BM.board_id").
 		Where(sq.Eq{"BM.user_id": userID})
 
-	rows, err := query.Query()
+	explicitMemberRows, err := query.Query()
+	if err != nil {
+		s.logger.Error(`getMembersForUser ERROR`, mlog.Err(err))
+		return nil, err
+	}
+	defer s.CloseRows(explicitMemberRows)
+
+	explicitMembers, err := s.boardMembersFromRows(explicitMemberRows)
+	if err != nil {
+		s.logger.Error(`getMembersForUser ERROR`, mlog.Err(err))
+		return nil, err
+	}
+
+	newQuery := s.getQueryBuilder(db).
+		Select("CM.userID, B.Id").
+		From(s.tablePrefix + "boards AS B").
+		Join("ChannelMembers AS CM ON B.channel_id=CM.channelId").
+		Where(sq.Eq{"CM.userID": userID})
+
+	rows, err := newQuery.Query()
 	if err != nil {
 		s.logger.Error(`getMembersForUser ERROR`, mlog.Err(err))
 		return nil, err
 	}
 	defer s.CloseRows(rows)
 
-	members, err := s.boardMembersFromRows(rows)
+	members := []*model.BoardMember{}
+	existingMembers := map[string]bool{}
+	for _, m := range explicitMembers {
+		members = append(members, m)
+		existingMembers[m.BoardID] = true
+	}
+
+	// No synthetic memberships for guests
+	user, err := s.GetUserByID(userID)
 	if err != nil {
 		return nil, err
+	}
+	if user.IsGuest {
+		return members, nil
+	}
+
+	implicitMembers, err := s.implicitBoardMembershipsFromRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	for _, m := range implicitMembers {
+		if !existingMembers[m.BoardID] {
+			members = append(members, m)
+		}
 	}
 
 	return members, nil
@@ -671,14 +734,55 @@ func (s *SQLStore) getMembersForBoard(db sq.BaseRunner, boardID string) ([]*mode
 		LeftJoin(s.tablePrefix + "boards AS B ON B.id=BM.board_id").
 		Where(sq.Eq{"BM.board_id": boardID})
 
-	rows, err := query.Query()
+	explicitMemberRows, err := query.Query()
+	if err != nil {
+		s.logger.Error(`getMembersForBoard ERROR`, mlog.Err(err))
+		return nil, err
+	}
+	defer s.CloseRows(explicitMemberRows)
+
+	explicitMembers, err := s.boardMembersFromRows(explicitMemberRows)
+	if err != nil {
+		s.logger.Error(`getMembersForBoard ERROR`, mlog.Err(err))
+		return nil, err
+	}
+
+	newQuery := s.getQueryBuilder(db).
+		Select("CM.userID, B.Id").
+		From(s.tablePrefix + "boards AS B").
+		Join("ChannelMembers AS CM ON B.channel_id=CM.channelId").
+		Join("Users as U on CM.userID = U.id").
+		LeftJoin("Bots as bo on U.id = bo.UserID").
+		Where(sq.Eq{"B.id": boardID}).
+		Where(sq.NotEq{"B.channel_id": ""}).
+		// Filter out guests as they don't have synthetic membership
+		Where(sq.NotEq{"U.roles": "system_guest"}).
+		Where(sq.Eq{"bo.UserId IS NOT NULL": false})
+
+	rows, err := newQuery.Query()
 	if err != nil {
 		s.logger.Error(`getMembersForBoard ERROR`, mlog.Err(err))
 		return nil, err
 	}
 	defer s.CloseRows(rows)
 
-	return s.boardMembersFromRows(rows)
+	implicitMembers, err := s.implicitBoardMembershipsFromRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	members := []*model.BoardMember{}
+	existingMembers := map[string]bool{}
+	for _, m := range explicitMembers {
+		members = append(members, m)
+		existingMembers[m.UserID] = true
+	}
+	for _, m := range implicitMembers {
+		if !existingMembers[m.UserID] {
+			members = append(members, m)
+		}
+	}
+
+	return members, nil
 }
 
 func (s *SQLStore) getBoardHistory(db sq.BaseRunner, boardID string, opts model.QueryBoardHistoryOptions) ([]*model.Board, error) {

--- a/server/services/store/sqlstore/board.go
+++ b/server/services/store/sqlstore/board.go
@@ -693,13 +693,13 @@ func (s *SQLStore) getMembersForUser(db sq.BaseRunner, userID string) ([]*model.
 		return explicitMembers, nil
 	}
 
-	newQuery := s.getQueryBuilder(db).
+	implicitMembersQuery := s.getQueryBuilder(db).
 		Select("CM.userID, B.Id").
 		From(s.tablePrefix + "boards AS B").
 		Join("ChannelMembers AS CM ON B.channel_id=CM.channelId").
 		Where(sq.Eq{"CM.userID": userID})
 
-	rows, err := newQuery.Query()
+	rows, err := implicitMembersQuery.Query()
 	if err != nil {
 		s.logger.Error(`getMembersForUser ERROR`, mlog.Err(err))
 		return nil, err
@@ -746,7 +746,7 @@ func (s *SQLStore) getMembersForBoard(db sq.BaseRunner, boardID string) ([]*mode
 		return nil, err
 	}
 
-	newQuery := s.getQueryBuilder(db).
+	implicitMembersQuery := s.getQueryBuilder(db).
 		Select("CM.userID, B.Id").
 		From(s.tablePrefix + "boards AS B").
 		Join("ChannelMembers AS CM ON B.channel_id=CM.channelId").
@@ -758,7 +758,7 @@ func (s *SQLStore) getMembersForBoard(db sq.BaseRunner, boardID string) ([]*mode
 		Where(sq.NotEq{"U.roles": "system_guest"}).
 		Where(sq.Eq{"bo.UserId IS NOT NULL": false})
 
-	rows, err := newQuery.Query()
+	rows, err := implicitMembersQuery.Query()
 	if err != nil {
 		s.logger.Error(`getMembersForBoard ERROR`, mlog.Err(err))
 		return nil, err


### PR DESCRIPTION
#### Summary
This PR addresses a regression where channel members could not see boards linked to the channel in the channel's board RHS or the boards LHS. The issue occurred because boards only checked for board membership, which previously relied on `Mattermost's auth layer`. When the auth layer was removed during the plugin refactoring, the related code was lost.

- https://github.com/mattermost-community/focalboard/blob/de5e5cc4141f14f69bf0e5666383997b81f851d6/server/services/store/mattermostauthlayer/mattermostauthlayer.go#L1052
- https://github.com/mattermost-community/focalboard/blob/de5e5cc4141f14f69bf0e5666383997b81f851d6/server/services/store/mattermostauthlayer/mattermostauthlayer.go#L1101


This fix ensures channel members can now see linked boards in both the channel RHS and the boards LHS. Additionally, I reviewed the removed `Mattermost auth layer` code and restored all the missing functionality in this PR.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61822