### PR TITLE
MM-61945: Able to add individual users to the boards

### DIFF
--- a/server/services/store/sqlstore/board.go
+++ b/server/services/store/sqlstore/board.go
@@ -568,7 +568,6 @@ func (s *SQLStore) getMemberForBoard(db sq.BaseRunner, boardID, userID string) (
 	defer s.CloseRows(rows)
 
 	members, err := s.boardMembersFromRows(rows)
-	fmt.Println("members", members)
 	if err != nil {
 		return nil, err
 	}

--- a/server/services/store/sqlstore/board.go
+++ b/server/services/store/sqlstore/board.go
@@ -568,6 +568,7 @@ func (s *SQLStore) getMemberForBoard(db sq.BaseRunner, boardID, userID string) (
 	defer s.CloseRows(rows)
 
 	members, err := s.boardMembersFromRows(rows)
+	fmt.Println("members", members)
 	if err != nil {
 		return nil, err
 	}
@@ -637,6 +638,7 @@ func (s *SQLStore) getMemberForBoard(db sq.BaseRunner, boardID, userID string) (
 				Synthetic:       true,
 			}, nil
 		}
+		return nil, nil
 	}
 
 	return members[0], nil


### PR DESCRIPTION
#### Summary
When adding individual members to the boards which were not part of the already linked boards was responded with 
`{error: "internal server error", "errorCode": 500}`. This was due to the server panicking if board members were not found. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61945
