### PR TITLE
Added linked and table renderer for markdown in comment

### DIFF
--- a/webapp/src/components/cardDetail/__snapshots__/comment.test.tsx.snap
+++ b/webapp/src/components/cardDetail/__snapshots__/comment.test.tsx.snap
@@ -118,9 +118,13 @@ exports[`components/cardDetail/comment return comment 1`] = `
       </div>
     </div>
     <div
-      class="mocked-message-html"
+      class="comment-markdown"
     >
-      Test Comment
+      <div
+        class="mocked-message-html"
+      >
+        Test Comment
+      </div>
     </div>
   </div>
 </div>
@@ -244,9 +248,13 @@ exports[`components/cardDetail/comment return comment and delete comment 1`] = `
       </div>
     </div>
     <div
-      class="mocked-message-html"
+      class="comment-markdown"
     >
-      Test Comment
+      <div
+        class="mocked-message-html"
+      >
+        Test Comment
+      </div>
     </div>
   </div>
 </div>
@@ -281,9 +289,13 @@ exports[`components/cardDetail/comment return comment readonly 1`] = `
       </div>
     </div>
     <div
-      class="mocked-message-html"
+      class="comment-markdown"
     >
-      Test Comment
+      <div
+        class="mocked-message-html"
+      >
+        Test Comment
+      </div>
     </div>
   </div>
 </div>
@@ -416,9 +428,13 @@ exports[`components/cardDetail/comment return guest comment 1`] = `
       </div>
     </div>
     <div
-      class="mocked-message-html"
+      class="comment-markdown"
     >
-      Test Comment
+      <div
+        class="mocked-message-html"
+      >
+        Test Comment
+      </div>
     </div>
   </div>
 </div>
@@ -551,9 +567,13 @@ exports[`components/cardDetail/comment return guest comment and delete comment 1
       </div>
     </div>
     <div
-      class="mocked-message-html"
+      class="comment-markdown"
     >
-      Test Comment
+      <div
+        class="mocked-message-html"
+      >
+        Test Comment
+      </div>
     </div>
   </div>
 </div>
@@ -597,9 +617,13 @@ exports[`components/cardDetail/comment return guest comment readonly 1`] = `
       </div>
     </div>
     <div
-      class="mocked-message-html"
+      class="comment-markdown"
     >
-      Test Comment
+      <div
+        class="mocked-message-html"
+      >
+        Test Comment
+      </div>
     </div>
   </div>
 </div>

--- a/webapp/src/components/cardDetail/__snapshots__/commentsList.test.tsx.snap
+++ b/webapp/src/components/cardDetail/__snapshots__/commentsList.test.tsx.snap
@@ -65,9 +65,13 @@ exports[`components/cardDetail/CommentsList comments show up 1`] = `
         </div>
       </div>
       <div
-        class="mocked-message-html"
+        class="comment-markdown"
       >
-        Test Comment
+        <div
+          class="mocked-message-html"
+        >
+          Test Comment
+        </div>
       </div>
     </div>
     <div
@@ -109,9 +113,13 @@ exports[`components/cardDetail/CommentsList comments show up 1`] = `
         </div>
       </div>
       <div
-        class="mocked-message-html"
+        class="comment-markdown"
       >
-        Test Comment
+        <div
+          class="mocked-message-html"
+        >
+          Test Comment
+        </div>
       </div>
     </div>
     <hr
@@ -151,9 +159,13 @@ exports[`components/cardDetail/CommentsList comments show up in readonly mode 1`
         </div>
       </div>
       <div
-        class="mocked-message-html"
+        class="comment-markdown"
       >
-        Test Comment
+        <div
+          class="mocked-message-html"
+        >
+          Test Comment
+        </div>
       </div>
     </div>
     <div
@@ -181,9 +193,13 @@ exports[`components/cardDetail/CommentsList comments show up in readonly mode 1`
         </div>
       </div>
       <div
-        class="mocked-message-html"
+        class="comment-markdown"
       >
-        Test Comment
+        <div
+          class="mocked-message-html"
+        >
+          Test Comment
+        </div>
       </div>
     </div>
     <hr

--- a/webapp/src/components/cardDetail/comment.scss
+++ b/webapp/src/components/cardDetail/comment.scss
@@ -64,4 +64,8 @@
     .comment-text * {
         user-select: text;
     }
+
+    .comment-markdown {
+        white-space: pre-wrap;
+    }
 }

--- a/webapp/src/components/cardDetail/comment.tsx
+++ b/webapp/src/components/cardDetail/comment.tsx
@@ -44,9 +44,8 @@ const Comment: FC<Props> = (props: Props) => {
     const formattedText = 
     <Provider store={(window as any).store}>
         {messageHtmlToComponent(formatText(comment.title, {
-            singleline: false,
+            renderer: Utils.getMarkdownRenderer(),
             atMentions: true,
-            mentionHighlight: false,
             team: selectedTeam,
             channelNamesMap,
         }), {

--- a/webapp/src/components/cardDetail/comment.tsx
+++ b/webapp/src/components/cardDetail/comment.tsx
@@ -86,7 +86,9 @@ const Comment: FC<Props> = (props: Props) => {
                     </MenuWrapper>
                 )}
             </div>
-            {formattedText}
+            <div className='comment-markdown'>
+                {formattedText}
+            </div>
         </div>
     )
 }

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -308,6 +308,28 @@ class Utils {
         return this.htmlFromMarkdownWithRenderer(text, renderer)
     }
 
+    static getMarkdownRenderer(): marked.Renderer {
+        marked.setOptions({
+            gfm: true,
+            breaks: true,
+        })
+        const renderer = new marked.Renderer()
+        renderer.link = (href, title, contents) => {
+            return '<a ' +
+                'target="_blank" ' +
+                'rel="noreferrer" ' +
+                `href="${encodeURI(decodeURI(href || ''))}" ` +
+                `title="${title || ''}" ` +
+                `onclick="${(window.openInNewBrowser ? ' openInNewBrowser && openInNewBrowser(event.target.href);' : '')}"` +
+            '>' + contents + '</a>'
+        }
+
+        renderer.table = (header, body) => {
+            return `<div class="table-responsive"><table class="markdown__table"><thead>${header}</thead><tbody>${body}</tbody></table></div>`
+        } 
+        return renderer
+    }
+
     static htmlFromMarkdownWithRenderer(text: string, renderer: marked.Renderer): string {
         const html = marked(text.replace(/</g, '&lt;'), {renderer, breaks: true})
         return html.trim()

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -289,22 +289,7 @@ class Utils {
     // Markdown
 
     static htmlFromMarkdown(text: string): string {
-        // HACKHACK: Somehow, marked doesn't encode angle brackets
-        const renderer = new marked.Renderer()
-        renderer.link = (href, title, contents) => {
-            return '<a ' +
-                'target="_blank" ' +
-                'rel="noreferrer" ' +
-                `href="${encodeURI(decodeURI(href || ''))}" ` +
-                `title="${title || ''}" ` +
-                `onclick="${(window.openInNewBrowser ? ' openInNewBrowser && openInNewBrowser(event.target.href);' : '')}"` +
-            '>' + contents + '</a>'
-        }
-
-        renderer.table = (header, body) => {
-            return `<div class="table-responsive"><table class="markdown__table"><thead>${header}</thead><tbody>${body}</tbody></table></div>`
-        }
-
+        const renderer = this.getMarkdownRenderer() 
         return this.htmlFromMarkdownWithRenderer(text, renderer)
     }
 

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -309,10 +309,6 @@ class Utils {
     }
 
     static getMarkdownRenderer(): marked.Renderer {
-        marked.setOptions({
-            gfm: true,
-            breaks: true,
-        })
         const renderer = new marked.Renderer()
         renderer.link = (href, title, contents) => {
             return '<a ' +

--- a/webapp/src/webapp_globals.ts
+++ b/webapp/src/webapp_globals.ts
@@ -5,15 +5,16 @@ import {NameMappedObjects} from "mattermost-redux/types/utilities"
 
 import {Channel} from "mattermost-redux/types/channels"
 
+import {Renderer} from "marked"
+
 import {Team} from "./store/teams"
 
 
 type Options = {
-    singleline: boolean;
     atMentions: boolean;
-    mentionHighlight: boolean;
     team: Team | null;
     channelNamesMap: NameMappedObjects<Channel>;
+    renderer: Renderer;
 }
 
 type Props = {


### PR DESCRIPTION
#### Summary
Markdown in board card comments was not functioning as expected because the `formatText` function failed to set the `breaks` property to `true` in the markdown renderer. In the WebApp, this is handled by the CSS property `white-space: pre-wrap`, eliminating the need to explicitly set the `breaks` property. To resolve the issue, the same approach has been implemented in the boards plugin. Additionally, a custom link and table renderer, previously used in boards, has been reintroduced.

For more details: https://hub.mattermost.com/icu/pl/urix3jcxrfdmin63h5k3k6ab4y

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61959

Before: 

![image (1)](https://github.com/user-attachments/assets/13a888d0-d4b8-411e-ad35-2973efbece70)
![image (3)](https://github.com/user-attachments/assets/d0456a90-4f8a-4369-8ee3-3cdee1228ca3)


After: 

![Screenshot 2024-11-26 at 12 13 32 AM](https://github.com/user-attachments/assets/55d10c74-644e-4e6f-9199-71b24a4b5c82)
