### PR TITLE
MM-62104 Fix board disappearing or move to default category when switching teams

### DIFF
--- a/webapp/src/components/sidebar/sidebar.test.tsx
+++ b/webapp/src/components/sidebar/sidebar.test.tsx
@@ -7,12 +7,13 @@ import {createMemoryHistory} from 'history'
 import {Provider as ReduxProvider} from 'react-redux'
 import {Router} from 'react-router-dom'
 
-import {render} from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import {render, waitFor} from '@testing-library/react'
 
 import thunk from 'redux-thunk'
 
 import {mocked} from 'jest-mock'
+
+import userEvent from '@testing-library/user-event'
 
 import {mockMatchMedia, wrapIntl} from '../../testUtils'
 
@@ -306,7 +307,7 @@ describe('components/sidebarSidebar', () => {
         expect(sidebarCollapsedCategory.length).toBe(1)
     })
 
-    test('should assign default category if current board doesnt have a category', () => {
+    test('should assign default category if current board doesnt have a category', async () => {
         const board2 = TestBlockFactory.createBoard()
         board2.id = 'board2'
 
@@ -362,7 +363,9 @@ describe('components/sidebarSidebar', () => {
         const {container} = render(component)
         expect(container).toMatchSnapshot()
 
-        expect(mockedOctoClient.moveBoardToCategory).toBeCalledWith('team-id', 'board2', 'default_category', '')
+        await waitFor(() => 
+            expect(mockedOctoClient.moveBoardToCategory).toBeCalledWith('team-id', 'board2', 'default_category', '')
+        )
     })
 
     test('shouldnt do any category assignment is board is in a category', () => {

--- a/webapp/src/components/sidebar/sidebar.tsx
+++ b/webapp/src/components/sidebar/sidebar.tsx
@@ -75,6 +75,7 @@ const Sidebar = (props: Props) => {
     const me = useAppSelector<IUser|null>(getMe)
     const activeViewID = useAppSelector(getCurrentViewId)
     const currentBoard = useAppSelector(getCurrentBoard)
+    const [initialized, setInitialized] = useState(false)
 
     useEffect(() => {
         const categoryOnChangeHandler = (_: WSClient, categories: Category[]) => {
@@ -98,11 +99,14 @@ const Sidebar = (props: Props) => {
     const team = useAppSelector(getCurrentTeam)
 
     useEffect(() => {
+        setInitialized(false)
         if (team) {
-            dispatch(fetchSidebarCategories(team!.id))
+            dispatch(fetchSidebarCategories(team!.id)).then(() => {
+                setInitialized(true)
+            })
         }
         loadTheme()
-    }, [team?.id])
+    }, [team?.id, dispatch])
 
     useEffect(() => {
         function handleResize() {
@@ -125,7 +129,7 @@ const Sidebar = (props: Props) => {
     // because there is no good, explicit API call to add this logic to when opening
     // a board that you have implicit access to.
     useEffect(() => {
-        if (!sidebarCategories || sidebarCategories.length === 0 || !currentBoard || !team || currentBoard.isTemplate) {
+        if (!initialized || !sidebarCategories || sidebarCategories.length === 0 || !currentBoard || !team || currentBoard.isTemplate) {
             return
         }
 
@@ -147,7 +151,7 @@ const Sidebar = (props: Props) => {
         }
 
         octoClient.moveBoardToCategory(team.id, currentBoard.id, boardsCategory.id, '')
-    }, [sidebarCategories, currentBoard, team])
+    }, [sidebarCategories, currentBoard, team, initialized])
 
     useWebsockets(teamId, (websocketClient: WSClient) => {
         const onCategoryReorderHandler = (_: WSClient, newCategoryOrder: string[]): void => {


### PR DESCRIPTION
#### Summary
I was able to identify a way to reproduce this issue and pinpoint its root cause. This issue has been present for a long time, even before the pre-split.

Steps to Reproduce:

- Create a category in the board sidebar.
- Create a board within that category.
- Observe that there are now two categories in the sidebar: the one you created and the default `Boards` category.
- Switch to a different team.
- Switch back to the team where you created the category.
- Observe the issue: the board is either no longer in the created category or has been moved to the default `Boards` category.

Root Cause: This is a client-side issue caused by a [this](https://github.com/mattermost/mattermost-plugin-boards/blob/c95e6e871588ed8a2311c4266733ebf49b4b6b02/webapp/src/components/sidebar/sidebar.tsx#L127) `useEffect` that executes before the Redux store is updated with the latest sidebar information. As a result, the `/api/v2/teams/{teamID}/categories/{categoryId}/boards/{boardID}` API is called with an empty `categoryId`. This causes the board to be incorrectly moved to the default `Boards` category.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62104
