### PR TITLE
Fix the comments link and markdown rendering issue

### DIFF
--- a/webapp/src/components/cardDetail/comment.scss
+++ b/webapp/src/components/cardDetail/comment.scss
@@ -65,7 +65,7 @@
         user-select: text;
     }
 
-    .comment-markdown {
+    .comment-markdown > * {
         white-space: pre-wrap;
     }
 }

--- a/webapp/src/components/cardDetail/comment.tsx
+++ b/webapp/src/components/cardDetail/comment.tsx
@@ -44,7 +44,6 @@ const Comment: FC<Props> = (props: Props) => {
     const formattedText = 
     <Provider store={(window as any).store}>
         {messageHtmlToComponent(formatText(comment.title, {
-            renderer: Utils.getMarkdownRenderer(),
             atMentions: true,
             team: selectedTeam,
             channelNamesMap,

--- a/webapp/src/webapp_globals.ts
+++ b/webapp/src/webapp_globals.ts
@@ -5,8 +5,6 @@ import {NameMappedObjects} from "mattermost-redux/types/utilities"
 
 import {Channel} from "mattermost-redux/types/channels"
 
-import {Renderer} from "marked"
-
 import {Team} from "./store/teams"
 
 
@@ -14,7 +12,6 @@ type Options = {
     atMentions: boolean;
     team: Team | null;
     channelNamesMap: NameMappedObjects<Channel>;
-    renderer: Renderer;
 }
 
 type Props = {


### PR DESCRIPTION
#### Summary
The card with links in the comments was not opening inside the boards. Error when opening the card with a link on the hub in the console: 

```bash
console.js:288 EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self' cdn.rudderlabs.com".

focalboard_9ce1515f8964ad29_bundle.js:2 [1734085501.12] error boundary redirecting to plugins/focalboard/error?id=unknown
```

This is because of the `Content-Security-Policy` Policy in webapp. This policy restricts the use of unsafe javascript methods like `new Functions()`, which can be exploited in injection attacks.


Before we were using the board markdown renderer which was working fine, but due to [Respect display name configuration PR](https://github.com/mattermost/mattermost-plugin-boards/pull/22)  the boards now use the Markdown renderer from the web app (Channels).

The current Markdown renderer includes a custom link rendering function:

```javascript
renderer.link = (href, title, contents) => {
            return '<a ' +
                'target="_blank" ' +
                'rel="noreferrer" ' +
                `href="${encodeURI(decodeURI(href || ''))}" ` +
                `title="${title || ''}" ` +
                `onclick="${(window.openInNewBrowser ? ' openInNewBrowser && openInNewBrowser(event.target.href);' : '')}"` +
            '>' + contents + '</a>'
        }
```

 the link function in the above custom Markdown renderer contributed to the unsafe-eval CSP error, specifically due to the inline `onclick` function. The `onclick` attribute in the rendered HTML attempts to execute JavaScript inline. CSP policies typically disallow inline scripts unless explicitly permitted using a CSP directive like 'unsafe-inline'.

Removing the `onclick` should fix this issue. Anyways `target='_blank'` will always open the link in a new tab. 

Also, there was a markdown rendering issue in the comments inside the cards. This was also fixed in this PR. 


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62243

Before: 

![Screenshot 2024-12-17 at 7 35 21 PM](https://github.com/user-attachments/assets/1e699f52-29b8-4186-8515-4802e4dba3fc)

After: 
![Screenshot 2024-12-17 at 7 37 08 PM](https://github.com/user-attachments/assets/82e5d390-42f2-4c4a-8eb1-045a64be640d)

