### PR TITLE
Migrate scorecard-analysis workflow to job token

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -13,9 +13,10 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecards analysis
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       # Needed to upload the results to code-scanning dashboard.
+      id-token: write
       security-events: write
       actions: read
       contents: read
@@ -31,9 +32,7 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          # Read-only PAT token. To create it,
-          # follow the steps in https://github.com/ossf/scorecard-action#pat-token-creation.
-          repo_token: ${{ secrets.SCORECARD_READ_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           # Publish the results to enable scorecard badges. For more details, see
           # https://github.com/ossf/scorecard-action#publishing-results.
           # For private repositories, `publish_results` will automatically be set to `false`,


### PR DESCRIPTION
#### Summary

Adapt the scorecard-analysis workflow to match the one used by the [scorecard repository itself](https://github.com/ossf/scorecard/blob/v5.0.0/.github/workflows/scorecard-analysis.yml).

[Here](https://github.com/ossf/scorecard-action?tab=readme-ov-file#breaking-changes-in-v2) are the scorecard-action docs, mentioning which permissions should the job token have, if `publish_results: true` is used
