### PR TITLE
MM-61745 Update Boards Navigation to Use the New Desktop API

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "focalboard",
-	"version": "8.0.0",
+	"version": "9.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "focalboard",
-			"version": "8.0.0",
+			"version": "9.0.0",
 			"dependencies": {
 				"@draft-js-plugins/editor": "^4.1.2",
 				"@draft-js-plugins/emoji": "^4.6.0",
@@ -17,6 +17,7 @@
 				"@fullcalendar/interaction": "^5.10.1",
 				"@fullcalendar/react": "^5.10.1",
 				"@mattermost/compass-icons": "^0.1.39",
+				"@mattermost/desktop-api": "5.10.0-2",
 				"@reduxjs/toolkit": "^1.8.0",
 				"@tippyjs/react": "4.2.6",
 				"color": "^4.2.1",
@@ -3953,6 +3954,19 @@
 			"version": "0.1.45",
 			"resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.45.tgz",
 			"integrity": "sha512-xNuQG6FpmIYh+7ZAP2Qs/kAgS/O23IWOMEymaVJHFvQq8buCLdQz/b/2WgJZSLeoJjdfqhRMDDJmgaG2UEQD1w=="
+		},
+		"node_modules/@mattermost/desktop-api": {
+			"version": "5.10.0-2",
+			"resolved": "https://registry.npmjs.org/@mattermost/desktop-api/-/desktop-api-5.10.0-2.tgz",
+			"integrity": "sha512-Okb+VP6gdwEBnSthzxiU3+oO5XLTocDvWlzoGYjBYrT4DN2/xxAzRYgp1VB6skQxEwVhbP/zaQvWbRtZrp8org==",
+			"peerDependencies": {
+				"typescript": "^4.3.0 || ^5.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -28929,6 +28943,12 @@
 			"version": "0.1.45",
 			"resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.45.tgz",
 			"integrity": "sha512-xNuQG6FpmIYh+7ZAP2Qs/kAgS/O23IWOMEymaVJHFvQq8buCLdQz/b/2WgJZSLeoJjdfqhRMDDJmgaG2UEQD1w=="
+		},
+		"@mattermost/desktop-api": {
+			"version": "5.10.0-2",
+			"resolved": "https://registry.npmjs.org/@mattermost/desktop-api/-/desktop-api-5.10.0-2.tgz",
+			"integrity": "sha512-Okb+VP6gdwEBnSthzxiU3+oO5XLTocDvWlzoGYjBYrT4DN2/xxAzRYgp1VB6skQxEwVhbP/zaQvWbRtZrp8org==",
+			"requires": {}
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -39,6 +39,7 @@
 		"@fullcalendar/interaction": "^5.10.1",
 		"@fullcalendar/react": "^5.10.1",
 		"@mattermost/compass-icons": "^0.1.39",
+		"@mattermost/desktop-api": "5.10.0-2",
 		"@reduxjs/toolkit": "^1.8.0",
 		"@tippyjs/react": "4.2.6",
 		"color": "^4.2.1",

--- a/webapp/src/types/index.d.ts
+++ b/webapp/src/types/index.d.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {DesktopAPI} from "@mattermost/desktop-api"
+
 type TelemetryProps = {
     trackingLocation: string
 }
@@ -25,4 +27,5 @@ export type SuiteWindow = Window & {
     frontendBaseURL?: string
     isFocalboardPlugin?: boolean
     WebappUtils?: any
+    desktopAPI?: Partial<DesktopAPI>
 }


### PR DESCRIPTION
#### Summary

Boards have their own navigation module that depends on the Desktop App to forward links between tabs. In version 5.11, the Desktop App removed the old `postMessage` code that enabled this functionality. Since Boards has not yet migrated to the new system, some links no longer work. To resolve this, board navigation has been updated to use the new Desktop A

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61745

QA Steps: 
- Download and install the latest Mattermost Desktop nightly build: [v5.12.0-nightly.20250129](https://github.com/mattermost/desktop/releases/tag/5.12.0-nightly.20250129).
- Log in to Mattermost.
- Upload the boards built from the main branch.
- Attempt to open a card and navigate to other boards (navigation will not work).
- Build Boards from this branch.
- Repeat the same actions—navigation should now work as expected.
