### PR TITLE
doc: add dependencies installation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ you are building on.
 In your Mattermost configuration file, ensure that `PluginSettings.EnableUploads` is set to `true`, and `FileSettings.MaxFileSize` is
 set to a large enough value to accept the plugin bundle (eg `256000000`).
 
+### Installing Dependencies 
+
+```sh
+cd ./webapp
+npm install
+```
+
 ### Building the plugin
 
 Run the following command in the plugin repository to prepare a compiled, distributable plugin ZIP file:


### PR DESCRIPTION
- running `npm install` was missing from the README

#### Ticket Link

https://github.com/mattermost/mattermost-plugin-boards/issues/67