### PR TITLE
CSS: Allow to select and copy comments in a card

### DIFF
--- a/webapp/src/styles/main.scss
+++ b/webapp/src/styles/main.scss
@@ -37,7 +37,7 @@ html {
     * {
         box-sizing: border-box;
         outline: 0;
-        user-select: none;
+        user-select: text;
     }
 
     .TeamIcon {


### PR DESCRIPTION
#### Summary
This pull request changes the `user-select` value for `.focalboard-body *` from `none` to `text`. With this change, users are able to select and copy comments (either whole or parts of it). This is a functionality our Mattermost and Boards users request repeatedly because they have to be able to copy parts of comments for further usage (e.g., phone numbers or ticket/incident numbers; in our case, they are really long).

I couldn't think of any situation in which the current setting would be useful, but maybe I am missing something. Is there a reason that this was set to `none`?

#### Ticket Link
\-