### PR TITLE
MM-63181 Fix number formatting issue in Boards Plugin for CSV export

### DIFF
--- a/webapp/src/csvExporter.ts
+++ b/webapp/src/csvExporter.ts
@@ -87,7 +87,12 @@ class CsvExporter {
                 if (property.type === 'updatedBy') {
                     propertyValue = card.modifiedBy
                 }
-                row.push(property.exportValue(propertyValue, card, template, intl))
+                if (property.type === 'number') {
+                    const rawValue = property.exportValue(propertyValue, card, template, intl)
+                    row.push(`"${this.encodeText(rawValue)}"`)
+                } else {
+                    row.push(property.exportValue(propertyValue, card, template, intl))
+                } 
             })
             rows.push(row)
         })

--- a/webapp/src/properties/number/property.tsx
+++ b/webapp/src/properties/number/property.tsx
@@ -19,5 +19,5 @@ export default class NumberProperty extends PropertyType {
         Options.average, Options.median, Options.min, Options.max,
         Options.range]
 
-    exportValue = (value: string | string[] | undefined): string => (value ? Number(value).toString() : '')
+    exportValue = (value: string | string[] | undefined): string => (value ? value.toString() : '')
 }


### PR DESCRIPTION
#### Summary
You can enter numbers with commas, for example, as thousand or decimal separators depending on your locale, into number-type columns. But when exporting to CSV, those values were being treated as numbers, which sometimes led to issues like `NaN` showing up or the values getting split across multiple columns. This change fixes that by treating the values as plain text during export, so they’re preserved exactly as entered.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63181

