### PR TITLE
MM-63598 Fix unable to search for a portion of a word in a multiselect

### DIFF
--- a/webapp/src/store/cards.ts
+++ b/webapp/src/store/cards.ts
@@ -356,7 +356,7 @@ function searchFilterCards(cards: Card[], board: Board, searchTextRaw: string): 
                 } else if (propertyTemplate.type === 'multiSelect') {
                     // Look up the value of the select option
                     const options = (Array.isArray(propertyValue) ? propertyValue : [propertyValue]).map((value) => propertyTemplate.options.find((o) => o.id === value)?.value.toLowerCase())
-                    if (options?.includes(searchText)) {
+                    if (options.some((v) => v?.includes(searchText))) {
                         return true
                     }
                 } else if (propertyTemplate.type !== 'date' && (propertyValue.toString()).toLowerCase().includes(searchText)) {


### PR DESCRIPTION
#### Summary
A customer reported that search behaves differently depending on whether a card property is a `select` or `multiSelect` type.
For example:
- If a card has a `select` value of "single", typing "sing" or "ing" in the search bar correctly brings up that card.
- But if a card has a `multiSelect` value of "Banana", typing "ban" doesn’t return the card, only typing the full word "banana" works.

This feels inconsistent and confusing for users, especially since they expect both field types to support partial matches in the same way.
This PR fixes that by updating the `multiSelect` search logic to allow partial matching, just like `select` fields already do.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63598

