### PR TITLE
Fix: Boards | Windows : Flag emojis not working on Windows

### DIFF
--- a/webapp/src/components/blockIconSelector.tsx
+++ b/webapp/src/components/blockIconSelector.tsx
@@ -7,6 +7,8 @@ import {BlockIcons} from '../blockIcons'
 import {Card} from '../blocks/card'
 import mutator from '../mutator'
 
+import {getValidEmojiData} from '../utils/emojiUtils'
+
 import IconSelector from './iconSelector'
 
 type Props = {
@@ -29,11 +31,13 @@ const BlockIconSelector = (props: Props) => {
         return null
     }
 
+    const emojiData = getValidEmojiData(block.fields.icon)
+
     let className = `octo-icon size-${size || 'm'}`
     if (props.readonly) {
         className += ' readonly'
     }
-    const iconElement = <div className={className}><span>{block.fields.icon}</span></div>
+    const iconElement = <div className={className}><span>{emojiData?.native || block.fields.icon}</span></div>
 
     return (
         <IconSelector

--- a/webapp/src/components/boardIconSelector.tsx
+++ b/webapp/src/components/boardIconSelector.tsx
@@ -8,6 +8,8 @@ import {Board} from '../blocks/board'
 
 import mutator from '../mutator'
 
+import {getValidEmojiData} from '../utils/emojiUtils'
+
 import IconSelector from './iconSelector'
 
 type Props = {
@@ -30,11 +32,13 @@ const BoardIconSelector = React.memo((props: Props) => {
         return null
     }
 
+    const emojiData = getValidEmojiData(board.icon)
+
     let className = `octo-icon size-${size || 'm'}`
     if (props.readonly) {
         className += ' readonly'
     }
-    const iconElement = <div className={className}><span>{board.icon}</span></div>
+    const iconElement = <div className={className}><span>{emojiData?.native || board.icon}</span></div>
 
     return (
         <IconSelector

--- a/webapp/src/components/kanban/kanbanCard.tsx
+++ b/webapp/src/components/kanban/kanbanCard.tsx
@@ -21,6 +21,7 @@ import OpenCardTourStep from '../onboardingTour/openCard/open_card'
 import CopyLinkTourStep from '../onboardingTour/copyLink/copy_link'
 import CardActionsMenu from '../cardActionsMenu/cardActionsMenu'
 import CardActionsMenuIcon from '../cardActionsMenu/cardActionsMenuIcon'
+import {getValidEmojiData} from '../../utils/emojiUtils'
 
 export const OnboardingCardClassName = 'onboardingCard'
 
@@ -88,6 +89,10 @@ const KanbanCard = (props: Props) => {
 
     const isOnboardingCard = card.title === 'Create a new card'
     const showOnboarding = isOnboardingCard && !match.params.cardId && !board.isTemplate && Utils.isFocalboardPlugin()
+    let emojiData = null
+    if (card.fields.icon) {
+        emojiData = getValidEmojiData(card.fields.icon)
+    }
 
     return (
         <>
@@ -130,7 +135,7 @@ const KanbanCard = (props: Props) => {
                 }
 
                 <div className='octo-icontitle'>
-                    { card.fields.icon ? <div className='octo-icon'>{card.fields.icon}</div> : undefined }
+                    { card.fields.icon ? <div className='octo-icon'>{emojiData?.native || card.fields.icon}</div> : undefined }
                     <div
                         key='__title'
                         className='octo-titletext'

--- a/webapp/src/components/sidebar/sidebarBoardItem.tsx
+++ b/webapp/src/components/sidebar/sidebarBoardItem.tsx
@@ -6,6 +6,8 @@ import {useIntl} from 'react-intl'
 import {generatePath, useHistory, useRouteMatch} from 'react-router-dom'
 import {Draggable} from 'react-beautiful-dnd'
 
+import {BaseEmoji} from 'emoji-mart'
+
 import {Board} from '../../blocks/board'
 import {BoardView, IViewType} from '../../blocks/boardView'
 import mutator from '../../mutator'
@@ -41,6 +43,7 @@ import octoClient from '../../octoClient'
 import {getCurrentBoardId} from '../../store/boards'
 import {UserSettings} from '../../userSettings'
 import {Archiver} from '../../archiver'
+import {getValidEmojiData} from '../../utils/emojiUtils'
 
 const iconForViewType = (viewType: IViewType): JSX.Element => {
     switch (viewType) {
@@ -194,6 +197,10 @@ const SidebarBoardItem = (props: Props) => {
     const boardItemRef = useRef<HTMLDivElement>(null)
 
     const title = board.title || intl.formatMessage({id: 'Sidebar.untitled-board', defaultMessage: '(Untitled Board)'})
+    let emojiData: BaseEmoji | null  = null
+    if (board.icon) {
+        emojiData = getValidEmojiData(board.icon)
+    }
     return (
         <Draggable
             draggableId={props.board.id}
@@ -212,7 +219,7 @@ const SidebarBoardItem = (props: Props) => {
                         ref={boardItemRef}
                     >
                         <div className='octo-sidebar-icon'>
-                            {board.icon || <CompassIcon icon='product-boards'/>}
+                            {emojiData?.native || board.icon || <CompassIcon icon='product-boards'/>}
                         </div>
                         <div
                             className='octo-sidebar-title'

--- a/webapp/src/utils/emojiUtils.test.ts
+++ b/webapp/src/utils/emojiUtils.test.ts
@@ -1,0 +1,32 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {getValidEmojiData} from './emojiUtils'
+
+describe('getValidEmojiData', () => {
+    it('should return valid emoji data for a known emoji', () => {
+        const emoji = '😄' // smiling face
+        const result = getValidEmojiData(emoji)
+
+        expect(result).not.toBeNull()
+        expect(result?.native).toBe(emoji)
+        expect(result?.id).toBe('smile')
+    })
+
+    it('should return null for an invalid emoji', () => {
+        const invalidEmoji = 'not-an-emoji'
+        const result = getValidEmojiData(invalidEmoji)
+
+        expect(result).toBeNull()
+    })
+
+    it('should return correct metadata for a complex emoji (e.g. skin tone)', () => {
+        const emoji = '👍🏽'
+        const result = getValidEmojiData(emoji)
+
+        expect(result).not.toBeNull()
+        expect(result?.native).toBe(emoji)
+        expect(result?.id).toBe('+1')
+        expect(result?.skin).toBe(4) 
+    })
+})

--- a/webapp/src/utils/emojiUtils.ts
+++ b/webapp/src/utils/emojiUtils.ts
@@ -1,0 +1,15 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {getEmojiDataFromNative, BaseEmoji} from 'emoji-mart'
+import data from 'emoji-mart/data/all.json'
+
+const EMOJI_SET = 'apple' as const // Single source of truth
+
+export function getValidEmojiData(native: string): BaseEmoji | null {
+    try {
+        return getEmojiDataFromNative(native, EMOJI_SET, data)
+    } catch (err) {
+        return null
+    }
+}


### PR DESCRIPTION
#### Summary
Some emojis (for example, flag emojis) were not rendering properly on Windows systems due to platform-specific emoji support. To ensure consistent emoji rendering across platforms, I introduced a utility function `getValidEmojiData`, which wraps `emoji-mart`'s `getEmojiDataFromNative`. This allows us to retrieve normalised metadata for emojis and ensures we always use a valid native representation that the emoji-mart library can handle reliably.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63226

