### PR TITLE
Fix the Firstname and Lastname together search in person property

### DIFF
--- a/server/services/store/sqlstore/user.go
+++ b/server/services/store/sqlstore/user.go
@@ -318,6 +318,9 @@ func (s *SQLStore) getUsersList(_ sq.BaseRunner, userIDs []string, showEmail, sh
 }
 
 func (s *SQLStore) searchUsersByTeam(db sq.BaseRunner, teamID string, searchQuery string, asGuestID string, excludeBots, showEmail, showName bool) ([]*model.User, error) {
+	// Trim whitespace from search query to avoid matching trailing/leading spaces
+	searchQuery = strings.TrimSpace(searchQuery)
+
 	var fullNameField string
 	switch s.dbType {
 	case model.MysqlDBType:

--- a/server/services/store/sqlstore/user.go
+++ b/server/services/store/sqlstore/user.go
@@ -318,6 +318,16 @@ func (s *SQLStore) getUsersList(_ sq.BaseRunner, userIDs []string, showEmail, sh
 }
 
 func (s *SQLStore) searchUsersByTeam(db sq.BaseRunner, teamID string, searchQuery string, asGuestID string, excludeBots, showEmail, showName bool) ([]*model.User, error) {
+	var fullNameField string
+	switch s.dbType {
+	case model.MysqlDBType:
+		fullNameField = "LOWER(CONCAT(u.firstname, ' ', u.lastname))"
+	case model.PostgresDBType, model.SqliteDBType:
+		fullNameField = "LOWER(u.firstname || ' ' || u.lastname)"
+	default:
+		fullNameField = "LOWER(u.firstname || ' ' || u.lastname)"
+	}
+
 	query := s.baseUserQuery(showEmail, showName).
 		Where(sq.Eq{"u.deleteAt": 0}).
 		Where(sq.Or{
@@ -325,6 +335,7 @@ func (s *SQLStore) searchUsersByTeam(db sq.BaseRunner, teamID string, searchQuer
 			sq.Like{"LOWER(u.nickname)": "%" + strings.ToLower(searchQuery) + "%"},
 			sq.Like{"LOWER(u.firstname)": "%" + strings.ToLower(searchQuery) + "%"},
 			sq.Like{"LOWER(u.lastname)": "%" + strings.ToLower(searchQuery) + "%"},
+			sq.Like{fullNameField: "%" + strings.ToLower(searchQuery) + "%"},
 		}).
 		OrderBy("u.username").
 		Limit(10)


### PR DESCRIPTION
#### Summary
When searching for a person using both first name and last name in the person property on Boards, the user does not appear in the suggestions. This was because of the search condition 

```golang
Where(sq.Or{
    sq.Like{"LOWER(u.username)": "%" + strings.ToLower(searchQuery) + "%"},
    sq.Like{"LOWER(u.nickname)": "%" + strings.ToLower(searchQuery) + "%"},
    sq.Like{"LOWER(u.firstname)": "%" + strings.ToLower(searchQuery) + "%"},
    sq.Like{"LOWER(u.lastname)": "%" + strings.ToLower(searchQuery) + "%"},
})
```
When searching for "John Doe", no matches were found because the search term `john doe` doesn't exist in any single database field. 

Fix: We updated the query to also include a `fullNamefield` that concatenates the first and last name (based on the database type), allowing us to match against the full name string. This ensures that a user with both a matching first and last name will now appear in the suggestions.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64711
