### PR TITLE
MM-64521 Update tracking template ID generation for built-in template

### DIFF
--- a/server/integrationtests/work_template_test.go
+++ b/server/integrationtests/work_template_test.go
@@ -13,20 +13,20 @@ import (
 // the work template are present in the default templates.
 // If this fails, you might need to sync with the channels team.
 func TestGetTemplatesForWorkTemplate(t *testing.T) {
-	// map[name]trackingTemplateId
+	// map[name]trackingTemplateId (SHA256 hashes)
 	knownInWorkTemplates := map[string]string{
-		"Company Goals & OKRs":   "7ba22ccfdfac391d63dea5c4b8cde0de",
-		"Competitive Analysis":   "06f4bff367a7c2126fab2380c9dec23c",
-		"Content Calendar":       "c75fbd659d2258b5183af2236d176ab4",
-		"Meeting Agenda ":        "54fcf9c610f0ac5e4c522c0657c90602",
-		"Personal Goals ":        "7f32dc8d2ae008cfe56554e9363505cc",
-		"Personal Tasls ":        "dfb70c146a4584b8a21837477c7b5431",
-		"Project Tasks ":         "a4ec399ab4f2088b1051c3cdf1dde4c3",
-		"Roadmap ":               "b728c6ca730e2cfc229741c5a4712b65",
-		"Sales Pipeline CRM":     "ecc250bb7dff0fe02247f1110f097544",
-		"Sprint Planner ":        "99b74e26d2f5d0a9b346d43c0a7bfb09",
-		"Team Retrospective":     "e4f03181c4ced8edd4d53d33d569a086",
-		"User Research Sessions": "6c345c7f50f6833f78b7d0f08ce450a3",
+		"Company Goals & OKRs":   "7bd8aabce55f508a52954cc539aa6ab3654d48e093f183ba5a2aea12216a5712",
+		"Competitive Analysis":   "cc298948acc22c99120d6051dc06a468fd5877077ea6b4b712e0eaad387575eb",
+		"Content Calendar":       "1710c11b033156671179a32e5fc2824a71bdea818415e434dd47d2da0217c101",
+		"Meeting Agenda ":        "b03b2e5b9be6ded96b9c6d6d59923963bd9054894c9829d1b37054efa6084de9",
+		"Personal Goals ":        "3fd512dd973ecc8f8b3ffe066ea8409f040a4dfb57d1a75bec96ccb18ee0c135",
+		"Personal Tasls ":        "6a619fe3943d47ddbd0681b8c546230f7819dd86636264d34057bfb563787cee",
+		"Project Tasks ":         "da397037e9ad7e84d99783ae4fe01f752c1564191bf7bb464a93fb7624a803e7",
+		"Roadmap ":               "73bbe8436fac26b1361735078a1d3172bac669b696677fbb31c9f7a12690fe3f",
+		"Sales Pipeline CRM":     "e0675727acb40007c37a22ccc72f1f4b8a3a7992614fb1014a04593384cd8c82",
+		"Sprint Planner ":        "a80cc39d52b3f355df62629135a0f45d59654eaeae83f3112191659e159c6726",
+		"Team Retrospective":     "ca4a7cf46d979b1c0326cb4e9fc8b6b32707c0226bc3be5d1275b2076836a9da",
+		"User Research Sessions": "8e1be4728c34efd671387645cf45a5ad0c44a97e4101ec7fb69ee59f8c496a60",
 	}
 	th := SetupTestHelper(t).InitBasic()
 	defer th.TearDown()

--- a/server/services/store/sqlstore/board.go
+++ b/server/services/store/sqlstore/board.go
@@ -4,8 +4,7 @@
 package sqlstore
 
 import (
-	//nolint:gosec
-	"crypto/md5"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -273,9 +272,8 @@ func (s *SQLStore) getBoardsInTeamByIds(db sq.BaseRunner, boardIDs []string, tea
 func (s *SQLStore) insertBoard(db sq.BaseRunner, board *model.Board, userID string) (*model.Board, error) {
 	// Generate tracking IDs for in-built templates
 	if board.IsTemplate && board.TeamID == model.GlobalTeamID {
-		//nolint:gosec
-		// we don't need cryptographically secure hash, so MD5 is fine
-		board.Properties["trackingTemplateId"] = fmt.Sprintf("%x", md5.Sum([]byte(board.Title)))
+		// Use SHA256 for FIPS compliance
+		board.Properties["trackingTemplateId"] = fmt.Sprintf("%x", sha256.Sum256([]byte(board.Title)))
 	}
 
 	propertiesBytes, err := s.MarshalJSONB(board.Properties)


### PR DESCRIPTION
#### Summary
Updates built-in template tracking ID generation to use SHA256 instead of MD5, enabling deployment in FIPS-compliant environments. Updates corresponding tests with new hash values.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64521

