### PR TITLE
 Fix for Global Template Initialisation

### DIFF
--- a/server/app/files.go
+++ b/server/app/files.go
@@ -189,10 +189,10 @@ func (a *App) GetFileReader(teamID, boardID, filename string) (filestore.ReadClo
 				return nil, fmt.Errorf("GetFileReader: cannot validate board for GlobalTeamID: %w", err)
 			}
 			if !board.IsTemplate {
-				return nil, fmt.Errorf("GetFileReader: GlobalTeamID only allowed for template boards, got non-template board %s", boardID)
+				return nil, fmt.Errorf("GetFileReader: GlobalTeamID only allowed for template boards, got non-template board %s", boardID) //nolint:err113
 			}
 		} else {
-			return nil, fmt.Errorf("GetFileReader: invalid team ID for teamID %s", teamID)
+			return nil, fmt.Errorf("GetFileReader: invalid team ID for teamID %s", teamID) //nolint:err113
 		}
 	}
 	if err := model.IsValidId(boardID); err != nil {

--- a/server/app/files_test.go
+++ b/server/app/files_test.go
@@ -695,7 +695,7 @@ func TestGetDestinationFilePath(t *testing.T) {
 	t.Run("Should reject path traversal in template teamID", func(t *testing.T) {
 		result, err := getDestinationFilePath(true, "../../../etc", validBoardID, "filename")
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid team ID")
+		assert.Contains(t, err.Error(), "invalid teamID in ValidateTeamID")
 		assert.Equal(t, "", result)
 	})
 
@@ -735,7 +735,7 @@ func TestGetDestinationFilePath(t *testing.T) {
 		result, err := getDestinationFilePath(false, "0", validBoardID, "non-template-file.jpg")
 		// Global team ID should now be rejected for non-template operations for security
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid team ID")
+		assert.Contains(t, err.Error(), "invalid teamID in ValidateTeamID")
 		assert.Equal(t, "", result)
 	})
 
@@ -760,10 +760,9 @@ func TestGetDestinationFilePath(t *testing.T) {
 	})
 
 	t.Run("Should reject absolute paths in teamID", func(t *testing.T) {
-		// Test absolute path handling in teamID parameter
-		result, err := getDestinationFilePath(false, "/plugins/file.tar.gz", validBoardID, "filename")
+		result, err := getDestinationFilePath(true, "/plugins/file.tar.gz", validBoardID, "filename")
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid team ID")
+		assert.Contains(t, err.Error(), "invalid teamID in ValidateTeamID")
 		assert.Equal(t, "", result)
 	})
 

--- a/server/model/team.go
+++ b/server/model/team.go
@@ -5,7 +5,10 @@ package model
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
+
+	mm_model "github.com/mattermost/mattermost/server/public/model"
 )
 
 // Team is information global to a team
@@ -46,4 +49,13 @@ func TeamsFromJSON(data io.Reader) []*Team {
 	var teams []*Team
 	_ = json.NewDecoder(data).Decode(&teams)
 	return teams
+}
+
+func ValidateTeamID(teamID string, isTemplate bool) error {
+	// Validate inputs to ensure proper file path handling
+	// Only allow GlobalTeamID for template operations to prevent path traversal attacks
+	if !mm_model.IsValidId(teamID) && !(isTemplate && teamID == GlobalTeamID) {
+		return fmt.Errorf("invalid teamID in ValidateTeamID: %s", teamID)
+	}
+	return nil
 }

--- a/server/model/team.go
+++ b/server/model/team.go
@@ -55,7 +55,7 @@ func ValidateTeamID(teamID string, isTemplate bool) error {
 	// Validate inputs to ensure proper file path handling
 	// Only allow GlobalTeamID for template operations to prevent path traversal attacks
 	if !mm_model.IsValidId(teamID) && !(isTemplate && teamID == GlobalTeamID) {
-		return fmt.Errorf("invalid teamID in ValidateTeamID: %s", teamID)
+		return fmt.Errorf("invalid teamID in ValidateTeamID: %s", teamID) //nolint:err113
 	}
 	return nil
 }


### PR DESCRIPTION
#### Summary
Global template initialisation failed after #108 due to overly strict validation in `getDestinationFilePath()` that rejected team ID "0" (`GlobalTeamID`).
`Error: "cannot initialise global templates for team 0: invalid team ID for team 0"`
Impact: Only 3 templates were imported instead of 13 on fresh installations

#### Solution
Modified `getDestinationFilePath()` to allow `GlobalTeamID` ("0") for template operations while maintaining validation for other use cases:
```go
if !mm_model.IsValidId(teamID) && !(isTemplate && teamID == model.GlobalTeamID) {
    return "", fmt.Errorf("getDestinationFilePath: invalid team ID for teamID %s", teamID)
}
```

https://hub.mattermost.com/private-core/pl/fy98hhctff8fbf7ecnpx1qqcsa

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64688

