### PR TITLE
Added file ownership validation to file access endpoints

### DIFF
--- a/server/api/files.go
+++ b/server/api/files.go
@@ -303,6 +303,12 @@ func (a *API) getFileInfo(w http.ResponseWriter, r *http.Request) {
 	auditRec.AddMeta("teamID", teamID)
 	auditRec.AddMeta("filename", filename)
 
+	// Validate that the file belongs to the specified board and team
+	if err := a.app.ValidateFileOwnership(teamID, boardID, filename); err != nil {
+		a.errorResponse(w, r, model.NewErrPermission("access denied to file"))
+		return
+	}
+
 	fileInfo, err := a.app.GetFileInfo(filename)
 	if err != nil && !model.IsErrNotFound(err) {
 		a.errorResponse(w, r, err)
@@ -316,6 +322,7 @@ func (a *API) getFileInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	jsonBytesResponse(w, http.StatusOK, data)
+	auditRec.Success()
 }
 
 func (a *API) handleUploadFile(w http.ResponseWriter, r *http.Request) {

--- a/server/app/files.go
+++ b/server/app/files.go
@@ -110,6 +110,8 @@ func (a *App) ValidateFileOwnership(teamID, boardID, filename string) error {
 }
 
 // validateFileReferencedByBoard checks if a file is referenced by blocks in the specified board.
+// Files use different storage patterns (teamID/boardID/filename for templates, boards/YYYYMMDD/filename for regular files).
+// Path mismatches don't indicate malicious files, just different storage patterns.
 func (a *App) validateFileReferencedByBoard(boardID, filename string) error {
 	imageBlocks, err := a.store.GetBlocksWithType(boardID, model.TypeImage)
 	if err != nil {

--- a/server/app/files.go
+++ b/server/app/files.go
@@ -111,19 +111,33 @@ func (a *App) ValidateFileOwnership(teamID, boardID, filename string) error {
 
 // validateFileReferencedByBoard checks if a file is referenced by blocks in the specified board.
 func (a *App) validateFileReferencedByBoard(boardID, filename string) error {
-	blocks, err := a.GetBlocksForBoard(boardID)
+	imageBlocks, err := a.store.GetBlocksWithType(boardID, model.TypeImage)
 	if err != nil {
 		return err
 	}
 
-	for _, block := range blocks {
-		if block.Type == model.TypeImage || block.Type == model.TypeAttachment {
-			if fileID, ok := block.Fields[model.BlockFieldFileId].(string); ok && fileID == filename {
-				return nil
-			}
-			if attachmentID, ok := block.Fields[model.BlockFieldAttachmentId].(string); ok && attachmentID == filename {
-				return nil
-			}
+	attachmentBlocks, err := a.store.GetBlocksWithType(boardID, model.TypeAttachment)
+	if err != nil {
+		return err
+	}
+
+	// Check image blocks
+	for _, block := range imageBlocks {
+		if fileID, ok := block.Fields[model.BlockFieldFileId].(string); ok && fileID == filename {
+			return nil
+		}
+		if attachmentID, ok := block.Fields[model.BlockFieldAttachmentId].(string); ok && attachmentID == filename {
+			return nil
+		}
+	}
+
+	// Check attachment blocks
+	for _, block := range attachmentBlocks {
+		if fileID, ok := block.Fields[model.BlockFieldFileId].(string); ok && fileID == filename {
+			return nil
+		}
+		if attachmentID, ok := block.Fields[model.BlockFieldAttachmentId].(string); ok && attachmentID == filename {
+			return nil
 		}
 	}
 

--- a/server/app/files.go
+++ b/server/app/files.go
@@ -23,6 +23,7 @@ const emptyString = "empty"
 
 var errEmptyFilename = errors.New("IsFileArchived: empty filename not allowed")
 var ErrFileNotFound = errors.New("file not found")
+var ErrFileNotReferencedByBoard = errors.New("file not referenced by board")
 
 func (a *App) SaveFile(reader io.Reader, teamID, boardID, filename string, asTemplate bool) (string, error) {
 	// NOTE: File extension includes the dot
@@ -86,7 +87,7 @@ func (a *App) GetFileInfo(filename string) (*mm_model.FileInfo, error) {
 	return fileInfo, nil
 }
 
-// ValidateFileOwnership checks if a file belongs to the specified board and team
+// ValidateFileOwnership checks if a file belongs to the specified board and team.
 func (a *App) ValidateFileOwnership(teamID, boardID, filename string) error {
 	fileInfo, err := a.GetFileInfo(filename)
 	if err != nil {
@@ -108,7 +109,7 @@ func (a *App) ValidateFileOwnership(teamID, boardID, filename string) error {
 	return nil
 }
 
-// validateFileReferencedByBoard checks if a file is referenced by blocks in the specified board
+// validateFileReferencedByBoard checks if a file is referenced by blocks in the specified board.
 func (a *App) validateFileReferencedByBoard(boardID, filename string) error {
 	blocks, err := a.GetBlocksForBoard(boardID)
 	if err != nil {
@@ -126,7 +127,7 @@ func (a *App) validateFileReferencedByBoard(boardID, filename string) error {
 		}
 	}
 
-	return fmt.Errorf("file %s is not referenced by any block in board %s", filename, boardID)
+	return fmt.Errorf("%w: file %s is not referenced by any block in board %s", ErrFileNotReferencedByBoard, filename, boardID)
 }
 
 func (a *App) GetFile(teamID, boardID, fileName string) (*mm_model.FileInfo, filestore.ReadCloseSeeker, error) {

--- a/server/app/files_test.go
+++ b/server/app/files_test.go
@@ -1031,7 +1031,7 @@ func TestValidateFileOwnership(t *testing.T) {
 		err := th.App.ValidateFileOwnership(validTeamID, validBoardID, filename)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "file not found")
-  })
+	})
 }
 
 func TestGetFilePathWithGlobalTeamID(t *testing.T) {


### PR DESCRIPTION
### Summary
Adds validation to ensure files can only be accessed through their correct board and team context in file serving endpoints.

#### Problem: 
The file access endpoints (`/files/teams/{teamID}/{boardID}/{filename}` and `/files/teams/{teamID}/{boardID}/{filename}/info`) were not verifying that the requested file belonged to the specified board. This could lead to inconsistent behaviour when accessing files across different board contexts.

#### Solution: 
Added file ownership validation: New `ValidateFileOwnership()` function ensures files belong to the requested board and team
Dual validation approach:
For files with explicit `team/board` paths, validates the path structure
For files with newer storage format: validates that the file is referenced by blocks within the specified board
API-level protection: Added validation to both file-serving and file-info endpoints.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64660

