### PR TITLE
Fix the unlinking issue of board to channel

### DIFF
--- a/server/model/board.go
+++ b/server/model/board.go
@@ -373,7 +373,7 @@ func (p *BoardPatch) IsValid() error {
 		return InvalidBoardErr{"invalid-board-minimum-role"}
 	}
 
-	if p.ChannelID != nil && !mmModel.IsValidId(*p.ChannelID) {
+	if p.ChannelID != nil && *p.ChannelID != "" && !mmModel.IsValidId(*p.ChannelID) {
 		return InvalidBoardErr{"invalid-channel-id"}
 	}
 

--- a/server/model/board_test.go
+++ b/server/model/board_test.go
@@ -180,3 +180,41 @@ func TestBoardIsValidForImport(t *testing.T) {
 		require.EqualError(t, err, "invalid-board-minimum-role")
 	})
 }
+
+func TestBoardPatchIsValid(t *testing.T) {
+	t.Run("Should return nil for valid board patch with channel ID", func(t *testing.T) {
+		validChannelID := model.NewId()
+		patch := &BoardPatch{
+			ChannelID: &validChannelID,
+		}
+		err := patch.IsValid()
+		require.NoError(t, err)
+	})
+
+	t.Run("Should return nil for board patch with empty channel ID (unlinking)", func(t *testing.T) {
+		emptyChannelID := ""
+		patch := &BoardPatch{
+			ChannelID: &emptyChannelID,
+		}
+		err := patch.IsValid()
+		require.NoError(t, err)
+	})
+
+	t.Run("Should return error for board patch with invalid channel ID", func(t *testing.T) {
+		invalidChannelID := "invalid-channel-id"
+		patch := &BoardPatch{
+			ChannelID: &invalidChannelID,
+		}
+		err := patch.IsValid()
+		require.Error(t, err)
+		require.EqualError(t, err, "invalid-channel-id")
+	})
+
+	t.Run("Should return nil for board patch with nil channel ID", func(t *testing.T) {
+		patch := &BoardPatch{
+			ChannelID: nil,
+		}
+		err := patch.IsValid()
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
#### Summary
This PR fix the board unlinking issue with the channel. 

Problem: 
The issue was in the `BoardPatch.IsValid()` method in `server/model/board.go`. When unlinking a board from a channel, the API sends a patch with `ChannelID` set to an empty string "", but the validation logic wasn't handling this correctly. Updated the method to handle an empty `ChannelID`. 


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64805
