### PR TITLE
Fix: Public sharing board functionality broken in v9.0.0

### DIFF
--- a/server/api/auth.go
+++ b/server/api/auth.go
@@ -35,6 +35,6 @@ func (a *API) attachSession(handler func(w http.ResponseWriter, r *http.Request)
 			return
 		}
 
-		a.errorResponse(w, r, model.NewErrUnauthorized("Unauthorized"))
+		handler(w, r)
 	}
 }


### PR DESCRIPTION
#### Summary
#### Problem
Public board sharing stopped working after v9.0.0 when the standalone and plugin parts were split. Users accessing shared boards with read tokens receive 401 Unauthorised errors.

#### Root Cause
In v9.0.0, the attachSession function was incorrectly modified to reject all anonymous users, breaking the intended design where:
`sessionRequired`: Requires authentication
`attachSession`: Allows anonymous users with valid read tokens

#### Solution
Restore anonymous access fallback in `attachSession` by allowing requests without `Mattermost-User-Id` header to proceed to individual handlers, which properly validate read tokens.
Before: Anonymous requests → 401 Unauthorised
After: Anonymous requests → Handler validates read token → Allow/Deny appropriately

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65017
