### PR TITLE
Added checks for user and block for file and subscription

### DIFF
--- a/server/api/subscriptions.go
+++ b/server/api/subscriptions.go
@@ -73,11 +73,6 @@ func (a *API) handleCreateSubscription(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	session := ctx.Value(sessionContextKey).(*model.Session)
 
-	auditRec := a.makeAuditRecord(r, "createSubscription", audit.Fail)
-	defer a.audit.LogRecord(audit.LevelModify, auditRec)
-	auditRec.AddMeta("subscriber_id", sub.SubscriberID)
-	auditRec.AddMeta("block_id", sub.BlockID)
-
 	// User can only create subscriptions for themselves (for now)
 	if session.UserID != sub.SubscriberID {
 		a.errorResponse(w, r, model.NewErrBadRequest("userID and subscriberID mismatch"))
@@ -96,6 +91,11 @@ func (a *API) handleCreateSubscription(w http.ResponseWriter, r *http.Request) {
 		a.errorResponse(w, r, model.NewErrPermission("access denied to block"))
 		return
 	}
+
+	auditRec := a.makeAuditRecord(r, "createSubscription", audit.Fail)
+	defer a.audit.LogRecord(audit.LevelModify, auditRec)
+	auditRec.AddMeta("subscriber_id", sub.SubscriberID)
+	auditRec.AddMeta("block_id", sub.BlockID)
 
 	subNew, err := a.app.CreateSubscription(&sub)
 	if err != nil {


### PR DESCRIPTION
#### Summary
This PR ensure that only authorised users can subscribe to a block (must have view access to the block of the board)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64971