### PR TITLE
Fix undo deleted card created bu duplicating

### DIFF
--- a/webapp/src/mutator.ts
+++ b/webapp/src/mutator.ts
@@ -1050,8 +1050,9 @@ class Mutator {
                 }
                 return [blocks, newRootBlock.id]
             },
-            async (newBlocks: Block[]) => {
+            async (result: [Block[], string]) => {
                 await beforeUndo?.()
+                const [newBlocks] = result
                 const newRootBlock = newBlocks && newBlocks[0]
                 if (newRootBlock) {
                     await octoClient.deleteBlock(newRootBlock.boardId, newRootBlock.id)


### PR DESCRIPTION
#### Summary
#### Issue
When duplicating a card and then pressing Cmd+Z (undo), the operation failed with a 403 error. The API request being sent was:
```
/api/v2/boards/undefined/blocks/undefined
```
Both the board ID and block ID were undefined, which caused the request to fail, and the card was not deleted.

#### Root Cause
The bug was caused by a type mismatch between the duplicateCard redo function's return type and the undo function's parameter type.
In the `undomanager` implementation, when an operation is performed:
- The redo function executes immediately (during the initial duplication)
- Its return value is captured and stored
- When undo is triggered, this stored value is passed to the undo function

The duplicateCard function had:
- Redo function returns: `[Block[], string]` a tuple containing the blocks array and new card ID
- Undo function expected: `Block[]` just an array of blocks
When the tuple was passed to the undo function, it incorrectly interpreted the first element (the blocks array) as a single Block, causing boardId and id to be undefined.

#### Solution
Updated the undo function parameter type to match the redo function's return type ([Block[], string]), and properly destructured the tuple to extract the blocks array before accessing the block properties.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66566

