### PR TITLE
Update minimum server version to 10.7.0

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -7,7 +7,7 @@
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-boards/releases",
     "icon_path": "assets/starter-template-icon.svg",
     "version": "9.2.1",
-    "min_server_version": "7.2.0",
+    "min_server_version": "10.7.0",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",


### PR DESCRIPTION
This PR updates the minimum Mattermost server version requirement to 10.7.0.

Mattermost server v10.7+ includes critical fixes for plugin compatibility with Go 1.23+ (see https://github.com/mattermost/mattermost/pull/30386). This change ensures that the plugin will only run on server versions that include the necessary compatibility patches, preventing runtime failures related to Go 1.23+'s serialization changes.
