### PR TITLE
Validation to modify comments

### DIFF
--- a/server/api/blocks.go
+++ b/server/api/blocks.go
@@ -570,6 +570,13 @@ func (a *API) handlePatchBlock(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if block.Type == model.TypeComment && block.CreatedBy != userID {
+		if !a.permissions.HasPermissionToBoard(userID, boardID, model.PermissionDeleteOthersComments) {
+			a.errorResponse(w, r, model.NewErrPermission("access denied to modify others' comments"))
+			return
+		}
+	}
+
 	requestBody, err := io.ReadAll(r.Body)
 	if err != nil {
 		a.errorResponse(w, r, err)
@@ -673,6 +680,12 @@ func (a *API) handlePatchBlocks(w http.ResponseWriter, r *http.Request) {
 		if !a.permissions.HasPermissionToBoard(userID, block.BoardID, model.PermissionManageBoardCards) {
 			a.errorResponse(w, r, model.NewErrPermission("access denied to make board changesa"))
 			return
+		}
+		if block.Type == model.TypeComment && block.CreatedBy != userID {
+			if !a.permissions.HasPermissionToBoard(userID, block.BoardID, model.PermissionDeleteOthersComments) {
+				a.errorResponse(w, r, model.NewErrPermission("access denied to modify others' comments"))
+				return
+			}
 		}
 	}
 

--- a/server/services/store/sqlstore/blocks.go
+++ b/server/services/store/sqlstore/blocks.go
@@ -265,6 +265,14 @@ func (s *SQLStore) insertBlock(db sq.BaseRunner, block *model.Block, userID stri
 			"board_id",
 		)
 
+	// Preserve the original creator when updating an existing block
+	createdBy := userID
+	createAt := utils.GetMillis()
+	if existingBlock != nil {
+		createdBy = existingBlock.CreatedBy
+		createAt = existingBlock.CreateAt
+	}
+
 	insertQueryValues := map[string]interface{}{
 		"channel_id":            "",
 		"id":                    block.ID,
@@ -274,9 +282,9 @@ func (s *SQLStore) insertBlock(db sq.BaseRunner, block *model.Block, userID stri
 		"title":                 block.Title,
 		"fields":                fieldsJSON,
 		"delete_at":             block.DeleteAt,
-		"created_by":            userID,
+		"created_by":            createdBy,
 		"modified_by":           block.ModifiedBy,
-		"create_at":             utils.GetMillis(),
+		"create_at":             createAt,
 		"update_at":             block.UpdateAt,
 		"board_id":              block.BoardID,
 	}


### PR DESCRIPTION
#### Summary
This PR adds a check that prevents other users from modifying others' comments. Only the comment creator or user with `PermissionDeleteOthersComments` can modify comments. Also fixed the `insertBlock` function to preserve the original creator in the `blocks_history` table. Previously, the history incorrectly showed the modifier as the creator. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66752
