### PR TITLE
Fix: Filter not working correctly for text fields in Boards

### DIFF
--- a/webapp/src/cardFilter.test.ts
+++ b/webapp/src/cardFilter.test.ts
@@ -730,4 +730,71 @@ describe('src/cardFilter', () => {
             expect(result.length).toEqual(0)
         })
     })
+    describe('verify text field filtering with case-insensitive matching', () => {
+        const textCard = TestBlockFactory.createCard(board)
+        textCard.id = '2'
+        textCard.title = 'card2'
+        textCard.fields.properties.colorPropertyId = 'Red'
+
+        const template: IPropertyTemplate = {
+            id: 'colorPropertyId',
+            name: 'Color',
+            type: 'text',
+            options: [],
+        }
+
+        test('should match when filter value is "Red" and card value is "Red" (is condition)', () => {
+            const filterClauseIs = createFilterClause({propertyId: 'colorPropertyId', condition: 'is', values: ['Red']})
+            const result = CardFilter.isClauseMet(filterClauseIs, [template], textCard)
+            expect(result).toBeTruthy()
+        })
+
+        test('should match when filter value is "red" (lowercase) and card value is "Red" (is condition)', () => {
+            const filterClauseIs = createFilterClause({propertyId: 'colorPropertyId', condition: 'is', values: ['red']})
+            const result = CardFilter.isClauseMet(filterClauseIs, [template], textCard)
+            expect(result).toBeTruthy()
+        })
+
+        test('should match when filter value is "RED" (uppercase) and card value is "Red" (is condition)', () => {
+            const filterClauseIs = createFilterClause({propertyId: 'colorPropertyId', condition: 'is', values: ['RED']})
+            const result = CardFilter.isClauseMet(filterClauseIs, [template], textCard)
+            expect(result).toBeTruthy()
+        })
+
+        test('should match when filter value is "Red" and card value is "Red" (contains condition)', () => {
+            const filterClauseContains = createFilterClause({propertyId: 'colorPropertyId', condition: 'contains', values: ['Red']})
+            const result = CardFilter.isClauseMet(filterClauseContains, [template], textCard)
+            expect(result).toBeTruthy()
+        })
+
+        test('should match when filter value is "red" (lowercase) and card value is "Red" (contains condition)', () => {
+            const filterClauseContains = createFilterClause({propertyId: 'colorPropertyId', condition: 'contains', values: ['red']})
+            const result = CardFilter.isClauseMet(filterClauseContains, [template], textCard)
+            expect(result).toBeTruthy()
+        })
+
+        test('should match when filter value is "Red" and card value is "Red" (startsWith condition)', () => {
+            const filterClauseStartsWith = createFilterClause({propertyId: 'colorPropertyId', condition: 'startsWith', values: ['Red']})
+            const result = CardFilter.isClauseMet(filterClauseStartsWith, [template], textCard)
+            expect(result).toBeTruthy()
+        })
+
+        test('should match when filter value is "r" (lowercase) and card value is "Red" (startsWith condition)', () => {
+            const filterClauseStartsWith = createFilterClause({propertyId: 'colorPropertyId', condition: 'startsWith', values: ['r']})
+            const result = CardFilter.isClauseMet(filterClauseStartsWith, [template], textCard)
+            expect(result).toBeTruthy()
+        })
+
+        test('should match when filter value is "ed" and card value is "Red" (endsWith condition)', () => {
+            const filterClauseEndsWith = createFilterClause({propertyId: 'colorPropertyId', condition: 'endsWith', values: ['ed']})
+            const result = CardFilter.isClauseMet(filterClauseEndsWith, [template], textCard)
+            expect(result).toBeTruthy()
+        })
+
+        test('should match when filter value is "ED" (uppercase) and card value is "Red" (endsWith condition)', () => {
+            const filterClauseEndsWith = createFilterClause({propertyId: 'colorPropertyId', condition: 'endsWith', values: ['ED']})
+            const result = CardFilter.isClauseMet(filterClauseEndsWith, [template], textCard)
+            expect(result).toBeTruthy()
+        })
+    })
 })

--- a/webapp/src/cardFilter.ts
+++ b/webapp/src/cardFilter.ts
@@ -137,43 +137,43 @@ class CardFilter {
                 }
                 return dateValue.from === numericFilter
             }
-            return filter.values[0]?.toLowerCase() === value
+            return filter.values[0]?.toLowerCase() === (value as string || '').toLowerCase()
         }
         case 'contains': {
             if (filter.values.length === 0) {
                 return true
             }
-            return (value as string || '').includes(filter.values[0]?.toLowerCase())
+            return (value as string || '').toLowerCase().includes(filter.values[0]?.toLowerCase())
         }
         case 'notContains': {
             if (filter.values.length === 0) {
                 return true
             }
-            return !(value as string || '').includes(filter.values[0]?.toLowerCase())
+            return !(value as string || '').toLowerCase().includes(filter.values[0]?.toLowerCase())
         }
         case 'startsWith': {
             if (filter.values.length === 0) {
                 return true
             }
-            return (value as string || '').startsWith(filter.values[0]?.toLowerCase())
+            return (value as string || '').toLowerCase().startsWith(filter.values[0]?.toLowerCase())
         }
         case 'notStartsWith': {
             if (filter.values.length === 0) {
                 return true
             }
-            return !(value as string || '').startsWith(filter.values[0]?.toLowerCase())
+            return !(value as string || '').toLowerCase().startsWith(filter.values[0]?.toLowerCase())
         }
         case 'endsWith': {
             if (filter.values.length === 0) {
                 return true
             }
-            return (value as string || '').endsWith(filter.values[0]?.toLowerCase())
+            return (value as string || '').toLowerCase().endsWith(filter.values[0]?.toLowerCase())
         }
         case 'notEndsWith': {
             if (filter.values.length === 0) {
                 return true
             }
-            return !(value as string || '').endsWith(filter.values[0]?.toLowerCase())
+            return !(value as string || '').toLowerCase().endsWith(filter.values[0]?.toLowerCase())
         }
         case 'isBefore': {
             if (filter.values.length === 0) {


### PR DESCRIPTION

#### Summary
Fixed a bug where text field filters failed when the filter text started with the first letter of the field value due to case-sensitive matching.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66631



https://github.com/user-attachments/assets/da903866-8022-4413-822f-16552da9cdd7


