### PR TITLE
Fix: Viewer Role can Accessing Individual Cards if part of board

### DIFF
--- a/server/api/cards.go
+++ b/server/api/cards.go
@@ -363,7 +363,7 @@ func (a *API) handleGetCard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !a.permissions.HasPermissionToBoard(userID, card.BoardID, model.PermissionManageBoardCards) {
+	if !a.permissions.HasPermissionToBoard(userID, card.BoardID, model.PermissionViewBoard) {
 		a.errorResponse(w, r, model.NewErrPermission("access denied to fetch card"))
 		return
 	}


### PR DESCRIPTION
#### Summary
Fixed: User with viewer role can access card with API. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67167

