### PR TITLE
Board blank page if no team id is present in localstorage

### DIFF
--- a/webapp/src/router.tsx
+++ b/webapp/src/router.tsx
@@ -70,13 +70,14 @@ function HomeToCurrentTeam(props: {path: string, exact: boolean}) {
 
                 let teamID = (window.getCurrentTeamId && window.getCurrentTeamId()) || ''
                 const lastTeamID = UserSettings.lastTeamId
+                const hasNoTeamId = !teamID && !firstTeam && !lastTeamID
                 
-                if (teamsFetchError && !teamID && !firstTeam && !lastTeamID) {
+                if (teamsFetchError && hasNoTeamId) {
                     history.replace('/error?id=unknown')
                     return null
                 }
                 
-                if (!teamID && !firstTeam && !lastTeamID && !teamsFetched) {
+                if (hasNoTeamId && !teamsFetched) {
                     return <></>
                 }
                 


### PR DESCRIPTION
#### Summary
Found an issue where if no team Id is present in the localstorage, the board on refresh on the page with URL `boards/team` goes blank. This PR solves this issue. It fetches the team ID from the API call, looks for the first team and redirects it to that team. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67431

