### PR TITLE
ci: add permissions to dist step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       run: cd focalboard; make server-ci
       
   dist:
+    permissions:
+      contents: read
+      id-token: write
     uses: mattermost/actions-workflows/.github/workflows/plugin-dist-pr.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
#### Summary
```
Invalid workflow file: .github/workflows/ci.yml#L49
The workflow is not valid. .github/workflows/ci.yml (Line: 49, Col: 3): Error calling workflow 'mattermost/actions-workflows/.github/workflows/plugin-dist-pr.yml@main'. The workflow is requesting 'id-token: write', but is only allowed 'id-token: none'.
```
https://github.com/mattermost/mattermost-plugin-boards/actions/runs/22130048096

Follow up from https://github.com/mattermost/mattermost-plugin-boards/pull/168

#### Ticket Link
- https://github.com/mattermost/mattermost-plugin-boards/pull/168


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration to enhance authorization settings for distribution processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->