### PR TITLE
Fix: Board infinity redirect multiperson property

### DIFF
--- a/webapp/src/store/cards.ts
+++ b/webapp/src/store/cards.ts
@@ -257,8 +257,16 @@ function sortCards(cards: Card[], lastCommentByCard: {[key: string]: CommentBloc
                     aValue = usersById[a.modifiedBy]?.username || ''
                     bValue = usersById[b.modifiedBy]?.username || ''
                 } else if (template.type === 'date') {
-                    aValue = (aValue === '') ? '' : JSON.parse(aValue as string).from
-                    bValue = (bValue === '') ? '' : JSON.parse(bValue as string).from
+                    try {
+                        aValue = (aValue === '') ? '' : JSON.parse(aValue as string).from
+                    } catch {
+                        aValue = ''
+                    }
+                    try {
+                        bValue = (bValue === '') ? '' : JSON.parse(bValue as string).from
+                    } catch {
+                        bValue = ''
+                    }
                 }
 
                 let result = 0
@@ -300,19 +308,29 @@ function sortCards(cards: Card[], lastCommentByCard: {[key: string]: CommentBloc
                     }
 
                     if (template.type === 'multiPerson') {
-                        aValue = Array.isArray(aValue) && aValue.length !== 0 && Object.keys(usersById).length > 0 ? aValue.map((id) => {
-                            if (usersById[id] !== undefined) {
-                                return usersById[id].username
-                            }
-                            return ''
-                        }).toString() : aValue
+                        if (Array.isArray(aValue) && aValue.length !== 0 && Object.keys(usersById).length > 0) {
+                            aValue = aValue.map((id) => {
+                                if (usersById[id] !== undefined) {
+                                    return usersById[id].username
+                                }
+                                return ''
+                            }).toString()
+                        } else if (Array.isArray(aValue)) {
+                            // When usersById is empty (e.g. during initial load before users are fetched),
+                            // convert array to string for localeCompare - avoid crash from array.localeCompare
+                            aValue = aValue.join(',')
+                        }
 
-                        bValue = Array.isArray(bValue) && bValue.length !== 0 && Object.keys(usersById).length > 0 ? bValue.map((id) => {
-                            if (usersById[id] !== undefined) {
-                                return usersById[id].username
-                            }
-                            return ''
-                        }).toString() : bValue
+                        if (Array.isArray(bValue) && bValue.length !== 0 && Object.keys(usersById).length > 0) {
+                            bValue = bValue.map((id) => {
+                                if (usersById[id] !== undefined) {
+                                    return usersById[id].username
+                                }
+                                return ''
+                            }).toString()
+                        } else if (Array.isArray(bValue)) {
+                            bValue = bValue.join(',')
+                        }
                     }
 
                     result = (aValue as string).localeCompare(bValue as string)

--- a/webapp/src/store/cards.ts
+++ b/webapp/src/store/cards.ts
@@ -308,28 +308,12 @@ function sortCards(cards: Card[], lastCommentByCard: {[key: string]: CommentBloc
                     }
 
                     if (template.type === 'multiPerson') {
-                        if (Array.isArray(aValue) && aValue.length !== 0 && Object.keys(usersById).length > 0) {
-                            aValue = aValue.map((id) => {
-                                if (usersById[id] !== undefined) {
-                                    return usersById[id].username
-                                }
-                                return ''
-                            }).toString()
-                        } else if (Array.isArray(aValue)) {
-                            // When usersById is empty (e.g. during initial load before users are fetched),
-                            // convert array to string for localeCompare - avoid crash from array.localeCompare
-                            aValue = aValue.join(',')
+                        if (Array.isArray(aValue)) {
+                            aValue = aValue.map((id) => usersById[id]?.username ?? '').toString()
                         }
 
-                        if (Array.isArray(bValue) && bValue.length !== 0 && Object.keys(usersById).length > 0) {
-                            bValue = bValue.map((id) => {
-                                if (usersById[id] !== undefined) {
-                                    return usersById[id].username
-                                }
-                                return ''
-                            }).toString()
-                        } else if (Array.isArray(bValue)) {
-                            bValue = bValue.join(',')
+                        if (Array.isArray(bValue)) {
+                            bValue = bValue.map((id) => usersById[id]?.username ?? '').toString()
                         }
                     }
 


### PR DESCRIPTION
#### Summary

Root Cause:
The crash happened in sortCards in `webapp/src/store/cards.ts` when:
- The board was sorted by a multi-person property.
- The page was refreshed.
- `boardUsers` was still empty because `fetchBoardMembers` had not finished.
- For multiPerson, the code only converted arrays to strings when usersById was non-empty.
- When `usersById` was empty, `aValue` and `bValue` stayed as arrays (e.g. ["user_id_1", "user_id_2"]).
- The code then called `(aValue as string).localeCompare(bValue as string)`.
- At runtime, aValue was still an array, so localeCompare was called on an array and caused TypeError: `aValue.localeCompare` is not a function.
- That error was caught by the React ErrorBoundary, which redirected to `/error?id=unknown`.

Steps to reproduce: 
- Create a new board with the template "Company Goals and OKRs"
- Create a new "board view" in the top left
- On one of the existing cards in the category, add a multi-person property
- Add yourself to this field on two of the cards in the view
- Set the sort for the view to that multi-person property
- After this, clicking the 3 dots and then “copy link” should produce links with the bug for any card on that view. Changing the sort to anything other than that property should also fix it.

Before: 

https://github.com/user-attachments/assets/9aea7580-9212-4d8f-8dcc-5f611c2e2554


After: 

https://github.com/user-attachments/assets/59d50ca2-c76c-4bb9-b701-85213059a39e



#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65641



