### PR TITLE
Fix the infinite redirect loop for boards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ env:
  EXCLUDE_ENTERPRISE: true
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ env:
  EXCLUDE_ENTERPRISE: true
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:

--- a/webapp/src/constants.ts
+++ b/webapp/src/constants.ts
@@ -203,10 +203,8 @@ class Constants {
 
     static readonly SystemUserID = 'system'
 
-    // SessionStorage keys for error handling
-    static readonly sessionStorageIgnoreStoredUrlsKey = 'board_ignore_stored_urls'
-    static readonly sessionStorageErrorRedirectCountKey = 'board_error_redirect_count'
-    static readonly sessionStorageErrorRedirectTimeKey = 'board_error_redirect_time'
+    // SessionStorage key to skip board auto-redirects after error
+    static readonly sessionStorageSkipBoardRedirectKey = 'skip_board_redirect'
 }
 
 export {Constants, Permission}

--- a/webapp/src/constants.ts
+++ b/webapp/src/constants.ts
@@ -202,6 +202,11 @@ class Constants {
     static readonly noChannelID = '0'
 
     static readonly SystemUserID = 'system'
+
+    // SessionStorage keys for error handling
+    static readonly sessionStorageIgnoreStoredUrlsKey = 'board_ignore_stored_urls'
+    static readonly sessionStorageErrorRedirectCountKey = 'board_error_redirect_count'
+    static readonly sessionStorageErrorRedirectTimeKey = 'board_error_redirect_time'
 }
 
 export {Constants, Permission}

--- a/webapp/src/error_boundary.tsx
+++ b/webapp/src/error_boundary.tsx
@@ -5,6 +5,7 @@
 import React from 'react'
 
 import {Utils} from './utils'
+import {Constants} from './constants'
 
 type State = {
     hasError: boolean
@@ -19,8 +20,33 @@ export default class ErrorBoundary extends React.Component<Props, State> {
     msg = 'Redirecting to error page...'
 
     handleError = (): void => {
-        const url = Utils.getBaseURL() + '/error?id=unknown'
-        Utils.log('error boundary redirecting to ' + url)
+        if (window.location.pathname.endsWith('/error')) {
+            return
+        }
+
+        // Loop detection: prevent infinite error redirects
+        const now = Date.now()
+        const lastRedirectTime = parseInt(sessionStorage.getItem(Constants.sessionStorageErrorRedirectTimeKey) || '0', 10)
+        const redirectCount = parseInt(sessionStorage.getItem(Constants.sessionStorageErrorRedirectCountKey) || '0', 10)
+
+        if (now - lastRedirectTime > 10000) {
+            sessionStorage.setItem(Constants.sessionStorageErrorRedirectCountKey, '1')
+            sessionStorage.setItem(Constants.sessionStorageErrorRedirectTimeKey, now.toString())
+        } else {
+            const newCount = redirectCount + 1
+            sessionStorage.setItem(Constants.sessionStorageErrorRedirectCountKey, newCount.toString())
+            sessionStorage.setItem(Constants.sessionStorageErrorRedirectTimeKey, now.toString())
+
+            // If redirected more than 3 times in 10 seconds, go to boards root
+            if (newCount > 3) {
+                sessionStorage.removeItem(Constants.sessionStorageErrorRedirectCountKey)
+                sessionStorage.removeItem(Constants.sessionStorageErrorRedirectTimeKey)
+                window.location.replace(Utils.getFrontendBaseURL(true))
+                return
+            }
+        }
+
+        const url = Utils.getFrontendBaseURL(true) + '/error?id=unknown'
         window.location.replace(url)
     }
 

--- a/webapp/src/error_boundary.tsx
+++ b/webapp/src/error_boundary.tsx
@@ -5,7 +5,6 @@
 import React from 'react'
 
 import {Utils} from './utils'
-import {Constants} from './constants'
 
 type State = {
     hasError: boolean
@@ -22,28 +21,6 @@ export default class ErrorBoundary extends React.Component<Props, State> {
     handleError = (): void => {
         if (window.location.pathname.endsWith('/error')) {
             return
-        }
-
-        // Loop detection: prevent infinite error redirects
-        const now = Date.now()
-        const lastRedirectTime = parseInt(sessionStorage.getItem(Constants.sessionStorageErrorRedirectTimeKey) || '0', 10)
-        const redirectCount = parseInt(sessionStorage.getItem(Constants.sessionStorageErrorRedirectCountKey) || '0', 10)
-
-        if (now - lastRedirectTime > 10000) {
-            sessionStorage.setItem(Constants.sessionStorageErrorRedirectCountKey, '1')
-            sessionStorage.setItem(Constants.sessionStorageErrorRedirectTimeKey, now.toString())
-        } else {
-            const newCount = redirectCount + 1
-            sessionStorage.setItem(Constants.sessionStorageErrorRedirectCountKey, newCount.toString())
-            sessionStorage.setItem(Constants.sessionStorageErrorRedirectTimeKey, now.toString())
-
-            // If redirected more than 3 times in 10 seconds, go to boards root
-            if (newCount > 3) {
-                sessionStorage.removeItem(Constants.sessionStorageErrorRedirectCountKey)
-                sessionStorage.removeItem(Constants.sessionStorageErrorRedirectTimeKey)
-                window.location.replace(Utils.getFrontendBaseURL(true))
-                return
-            }
         }
 
         const url = Utils.getFrontendBaseURL(true) + '/error?id=unknown'

--- a/webapp/src/error_boundary.tsx
+++ b/webapp/src/error_boundary.tsx
@@ -19,7 +19,9 @@ export default class ErrorBoundary extends React.Component<Props, State> {
     msg = 'Redirecting to error page...'
 
     handleError = (): void => {
-        if (window.location.pathname.endsWith('/error')) {
+        const frontendBase = Utils.getFrontendBaseURL()
+        const expectedErrorPathname = frontendBase ? `/${frontendBase}/error` : '/error'
+        if (window.location.pathname === expectedErrorPathname) {
             return
         }
 

--- a/webapp/src/error_boundary.tsx
+++ b/webapp/src/error_boundary.tsx
@@ -19,12 +19,6 @@ export default class ErrorBoundary extends React.Component<Props, State> {
     msg = 'Redirecting to error page...'
 
     handleError = (): void => {
-        const frontendBase = Utils.getFrontendBaseURL()
-        const expectedErrorPathname = frontendBase ? `/${frontendBase}/error` : '/error'
-        if (window.location.pathname === expectedErrorPathname) {
-            return
-        }
-
         const url = Utils.getFrontendBaseURL(true) + '/error?id=unknown'
         window.location.replace(url)
     }

--- a/webapp/src/pages/boardPage/boardPage.tsx
+++ b/webapp/src/pages/boardPage/boardPage.tsx
@@ -65,7 +65,7 @@ import WebsocketConnection from './websocketConnection'
 
 import './boardPage.scss'
 
-const MALFORMED_URL_PATTERNS = ['/error', 'plugins/', 'boards/', 'team/']
+const MALFORMED_URL_SEGMENTS = new Set(['error', 'plugins', 'boards', 'team'])
 
 type Props = {
     readonly?: boolean
@@ -92,18 +92,21 @@ const BoardPage = (props: Props): JSX.Element => {
 
     // Synchronous URL validation - runs before any data loading effects
     const isUrlMalformed = useMemo(() => {
-        const boardId = match.params.boardId
-        if (boardId && MALFORMED_URL_PATTERNS.some(pattern => boardId.includes(pattern))) {
+        const {boardId, viewId: viewIdParam, cardId} = match.params
+        if (boardId && MALFORMED_URL_SEGMENTS.has(boardId)) {
             Utils.logWarn(`Detected malformed boardId in URL: ${boardId}`)
             return true
         }
-        const viewIdParam = match.params.viewId
-        if (viewIdParam && MALFORMED_URL_PATTERNS.some(pattern => viewIdParam.includes(pattern))) {
+        if (viewIdParam && MALFORMED_URL_SEGMENTS.has(viewIdParam)) {
             Utils.logWarn(`Detected malformed viewId in URL: ${viewIdParam}`)
             return true
         }
+        if (cardId && MALFORMED_URL_SEGMENTS.has(cardId)) {
+            Utils.logWarn(`Detected malformed cardId in URL: ${cardId}`)
+            return true
+        }
         return false
-    }, [match.params.boardId, match.params.viewId])
+    }, [match.params.boardId, match.params.viewId, match.params.cardId])
 
     // if we're in a legacy route and not showing a shared board,
     // redirect to the new URL schema equivalent

--- a/webapp/src/pages/boardPage/boardPage.tsx
+++ b/webapp/src/pages/boardPage/boardPage.tsx
@@ -4,7 +4,7 @@
 import React, {useEffect, useState, useMemo, useCallback} from 'react'
 import {batch} from 'react-redux'
 import {FormattedMessage, useIntl} from 'react-intl'
-import {useRouteMatch, useHistory} from 'react-router-dom'
+import {Redirect, useRouteMatch, useHistory} from 'react-router-dom'
 
 import Workspace from '../../components/workspace'
 import VersionMessage from '../../components/messages/versionMessage'
@@ -65,6 +65,8 @@ import WebsocketConnection from './websocketConnection'
 
 import './boardPage.scss'
 
+const MALFORMED_URL_PATTERNS = ['/error', 'plugins/', 'boards/', 'team/']
+
 type Props = {
     readonly?: boolean
     new?: boolean
@@ -88,36 +90,20 @@ const BoardPage = (props: Props): JSX.Element => {
     const history = useHistory()
     const globalError = useAppSelector<string>(getGlobalError)
 
-    // Early parameter validation to prevent errors from malformed URLs
-    // This runs before any data loading or rendering logic
-    useEffect(() => {
-        // Validate boardId if present - should be a valid ID format (not contain 'error', 'plugins', etc.)
+    // Synchronous URL validation - runs before any data loading effects
+    const isUrlMalformed = useMemo(() => {
         const boardId = match.params.boardId
-        if (boardId) {
-            // Check if boardId looks malformed (contains path segments like 'error', 'plugins', 'boards', etc.)
-            const malformedPatterns = ['/error', 'plugins/', 'boards/', 'team/']
-            const isMalformed = malformedPatterns.some(pattern => boardId.includes(pattern))
-
-            if (isMalformed) {
-                Utils.logWarn(`Detected malformed boardId in URL: ${boardId}`)
-                history.replace('/error?id=unknown')
-                return
-            }
+        if (boardId && MALFORMED_URL_PATTERNS.some(pattern => boardId.includes(pattern))) {
+            Utils.logWarn(`Detected malformed boardId in URL: ${boardId}`)
+            return true
         }
-
-        // Validate viewId if present
         const viewIdParam = match.params.viewId
-        if (viewIdParam) {
-            const malformedPatterns = ['/error', 'plugins/', 'boards/', 'team/']
-            const isMalformed = malformedPatterns.some(pattern => viewIdParam.includes(pattern))
-
-            if (isMalformed) {
-                Utils.logWarn(`Detected malformed viewId in URL: ${viewIdParam}`)
-                history.replace('/error?id=unknown')
-                return
-            }
+        if (viewIdParam && MALFORMED_URL_PATTERNS.some(pattern => viewIdParam.includes(pattern))) {
+            Utils.logWarn(`Detected malformed viewId in URL: ${viewIdParam}`)
+            return true
         }
-    }, [match.params.boardId, match.params.viewId, history])
+        return false
+    }, [match.params.boardId, match.params.viewId])
 
     // if we're in a legacy route and not showing a shared board,
     // redirect to the new URL schema equivalent
@@ -193,6 +179,7 @@ const BoardPage = (props: Props): JSX.Element => {
         }
 
         const dispatchLoadAction = () => {
+            if (isUrlMalformed || !match.params.boardId) return
             dispatch(loadAction(match.params.boardId))
         }
 
@@ -220,7 +207,7 @@ const BoardPage = (props: Props): JSX.Element => {
             wsClient.removeOnChange(incrementalBoardMemberUpdate, 'boardMembers')
             wsClient.removeOnReconnect(dispatchLoadAction)
         }
-    }, [me?.id, activeBoardId])
+    }, [me?.id, activeBoardId, isUrlMalformed, match.params.boardId])
 
     const onConfirmJoin = async () => {
         if (me) {
@@ -301,6 +288,7 @@ const BoardPage = (props: Props): JSX.Element => {
     }, [])
 
     useEffect(() => {
+        if (isUrlMalformed) return
         dispatch(loadAction(match.params.boardId))
 
         if (match.params.boardId) {
@@ -316,13 +304,12 @@ const BoardPage = (props: Props): JSX.Element => {
                 }
             }
         }
-    }, [teamId, match.params.boardId, viewId, me?.id])
+    }, [teamId, match.params.boardId, viewId, me?.id, isUrlMalformed])
 
     useEffect(() => {
-        if (match.params.boardId && !props.readonly && me) {
-            loadOrJoinBoard(me, teamId, match.params.boardId)
-        }
-    }, [teamId, match.params.boardId, me?.id])
+        if (isUrlMalformed || !match.params.boardId || props.readonly || !me) return
+        loadOrJoinBoard(me, teamId, match.params.boardId)
+    }, [teamId, match.params.boardId, me?.id, isUrlMalformed])
 
     // Track when board has been loaded at least once
     useEffect(() => {
@@ -334,10 +321,9 @@ const BoardPage = (props: Props): JSX.Element => {
     // When the board is removed from the store while viewing (e.g. user was removed via websocket),
     // re-verify access so we show access-denied instead of the template picker
     useEffect(() => {
-        if (match.params.boardId && !props.readonly && me && !currentBoard && boardWasLoaded) {
-            loadOrJoinBoard(me, teamId, match.params.boardId)
-        }
-    }, [teamId, match.params.boardId, me?.id, currentBoard, loadOrJoinBoard, boardWasLoaded])
+        if (isUrlMalformed || !match.params.boardId || props.readonly || !me || currentBoard || !boardWasLoaded) return
+        loadOrJoinBoard(me, teamId, match.params.boardId)
+    }, [teamId, match.params.boardId, me?.id, currentBoard, loadOrJoinBoard, boardWasLoaded, isUrlMalformed])
 
     const handleUnhideBoard = async (boardID: string) => {
         if (!me || !category) {
@@ -348,14 +334,11 @@ const BoardPage = (props: Props): JSX.Element => {
     }
 
     useEffect(() => {
-        if (!teamId || !match.params.boardId) {
-            return
-        }
-
+        if (isUrlMalformed || !teamId || !match.params.boardId) return
         if (hiddenBoardIDs.indexOf(match.params.boardId) >= 0) {
             handleUnhideBoard(match.params.boardId)
         }
-    }, [me?.id, teamId, match.params.boardId])
+    }, [me?.id, teamId, match.params.boardId, isUrlMalformed])
 
     if (props.readonly) {
         useEffect(() => {
@@ -368,6 +351,10 @@ const BoardPage = (props: Props): JSX.Element => {
     // Don't render board if access is denied - GlobalErrorRedirect will handle the redirect
     if (globalError === ErrorId.AccessDenied || globalError === ErrorId.InvalidReadOnlyBoard) {
         return <></>
+    }
+
+    if (isUrlMalformed) {
+        return <Redirect to="/error?id=unknown"/>
     }
 
     return (

--- a/webapp/src/pages/boardPage/boardPage.tsx
+++ b/webapp/src/pages/boardPage/boardPage.tsx
@@ -4,7 +4,7 @@
 import React, {useEffect, useState, useMemo, useCallback} from 'react'
 import {batch} from 'react-redux'
 import {FormattedMessage, useIntl} from 'react-intl'
-import {Redirect, useRouteMatch, useHistory} from 'react-router-dom'
+import {useRouteMatch, useHistory} from 'react-router-dom'
 
 import Workspace from '../../components/workspace'
 import VersionMessage from '../../components/messages/versionMessage'
@@ -65,8 +65,6 @@ import WebsocketConnection from './websocketConnection'
 
 import './boardPage.scss'
 
-const MALFORMED_URL_SEGMENTS = new Set(['error', 'plugins', 'boards', 'team'])
-
 type Props = {
     readonly?: boolean
     new?: boolean
@@ -89,24 +87,6 @@ const BoardPage = (props: Props): JSX.Element => {
     const [boardWasLoaded, setBoardWasLoaded] = useState(false)
     const history = useHistory()
     const globalError = useAppSelector<string>(getGlobalError)
-
-    // Synchronous URL validation - runs before any data loading effects
-    const isUrlMalformed = useMemo(() => {
-        const {boardId, viewId: viewIdParam, cardId} = match.params
-        if (boardId && MALFORMED_URL_SEGMENTS.has(boardId)) {
-            Utils.logWarn(`Detected malformed boardId in URL: ${boardId}`)
-            return true
-        }
-        if (viewIdParam && MALFORMED_URL_SEGMENTS.has(viewIdParam)) {
-            Utils.logWarn(`Detected malformed viewId in URL: ${viewIdParam}`)
-            return true
-        }
-        if (cardId && MALFORMED_URL_SEGMENTS.has(cardId)) {
-            Utils.logWarn(`Detected malformed cardId in URL: ${cardId}`)
-            return true
-        }
-        return false
-    }, [match.params.boardId, match.params.viewId, match.params.cardId])
 
     // if we're in a legacy route and not showing a shared board,
     // redirect to the new URL schema equivalent
@@ -182,7 +162,7 @@ const BoardPage = (props: Props): JSX.Element => {
         }
 
         const dispatchLoadAction = () => {
-            if (isUrlMalformed || !match.params.boardId) return
+            if (!match.params.boardId) return
             dispatch(loadAction(match.params.boardId))
         }
 
@@ -210,7 +190,7 @@ const BoardPage = (props: Props): JSX.Element => {
             wsClient.removeOnChange(incrementalBoardMemberUpdate, 'boardMembers')
             wsClient.removeOnReconnect(dispatchLoadAction)
         }
-    }, [me?.id, activeBoardId, isUrlMalformed, match.params.boardId])
+    }, [me?.id, activeBoardId, match.params.boardId])
 
     const onConfirmJoin = async () => {
         if (me) {
@@ -291,7 +271,7 @@ const BoardPage = (props: Props): JSX.Element => {
     }, [])
 
     useEffect(() => {
-        if (isUrlMalformed || !match.params.boardId) return
+        if (!match.params.boardId) return
 
         dispatch(loadAction(match.params.boardId))
         dispatch(setCurrentBoard(match.params.boardId))
@@ -304,12 +284,12 @@ const BoardPage = (props: Props): JSX.Element => {
                 UserSettings.setLastViewId(match.params.boardId, viewId)
             }
         }
-    }, [teamId, match.params.boardId, viewId, me?.id, isUrlMalformed])
+    }, [teamId, match.params.boardId, viewId, me?.id])
 
     useEffect(() => {
-        if (isUrlMalformed || !match.params.boardId || props.readonly || !me) return
+        if (!match.params.boardId || props.readonly || !me) return
         loadOrJoinBoard(me, teamId, match.params.boardId)
-    }, [teamId, match.params.boardId, me?.id, isUrlMalformed])
+    }, [teamId, match.params.boardId, me?.id])
 
     // Track when board has been loaded at least once
     useEffect(() => {
@@ -321,9 +301,9 @@ const BoardPage = (props: Props): JSX.Element => {
     // When the board is removed from the store while viewing (e.g. user was removed via websocket),
     // re-verify access so we show access-denied instead of the template picker
     useEffect(() => {
-        if (isUrlMalformed || !match.params.boardId || props.readonly || !me || currentBoard || !boardWasLoaded) return
+        if (!match.params.boardId || props.readonly || !me || currentBoard || !boardWasLoaded) return
         loadOrJoinBoard(me, teamId, match.params.boardId)
-    }, [teamId, match.params.boardId, me?.id, currentBoard, loadOrJoinBoard, boardWasLoaded, isUrlMalformed])
+    }, [teamId, match.params.boardId, me?.id, currentBoard, loadOrJoinBoard, boardWasLoaded])
 
     const handleUnhideBoard = async (boardID: string) => {
         if (!me || !category) {
@@ -334,11 +314,11 @@ const BoardPage = (props: Props): JSX.Element => {
     }
 
     useEffect(() => {
-        if (isUrlMalformed || !teamId || !match.params.boardId) return
+        if (!teamId || !match.params.boardId) return
         if (hiddenBoardIDs.indexOf(match.params.boardId) >= 0) {
             handleUnhideBoard(match.params.boardId)
         }
-    }, [me?.id, teamId, match.params.boardId, isUrlMalformed])
+    }, [me?.id, teamId, match.params.boardId])
 
     if (props.readonly) {
         useEffect(() => {
@@ -351,10 +331,6 @@ const BoardPage = (props: Props): JSX.Element => {
     // Don't render board if access is denied - GlobalErrorRedirect will handle the redirect
     if (globalError === ErrorId.AccessDenied || globalError === ErrorId.InvalidReadOnlyBoard) {
         return <></>
-    }
-
-    if (isUrlMalformed) {
-        return <Redirect to="/error?id=unknown"/>
     }
 
     return (

--- a/webapp/src/pages/boardPage/boardPage.tsx
+++ b/webapp/src/pages/boardPage/boardPage.tsx
@@ -88,6 +88,37 @@ const BoardPage = (props: Props): JSX.Element => {
     const history = useHistory()
     const globalError = useAppSelector<string>(getGlobalError)
 
+    // Early parameter validation to prevent errors from malformed URLs
+    // This runs before any data loading or rendering logic
+    useEffect(() => {
+        // Validate boardId if present - should be a valid ID format (not contain 'error', 'plugins', etc.)
+        const boardId = match.params.boardId
+        if (boardId) {
+            // Check if boardId looks malformed (contains path segments like 'error', 'plugins', 'boards', etc.)
+            const malformedPatterns = ['/error', 'plugins/', 'boards/', 'team/']
+            const isMalformed = malformedPatterns.some(pattern => boardId.includes(pattern))
+
+            if (isMalformed) {
+                Utils.logWarn(`Detected malformed boardId in URL: ${boardId}`)
+                history.replace('/error?id=unknown')
+                return
+            }
+        }
+
+        // Validate viewId if present
+        const viewIdParam = match.params.viewId
+        if (viewIdParam) {
+            const malformedPatterns = ['/error', 'plugins/', 'boards/', 'team/']
+            const isMalformed = malformedPatterns.some(pattern => viewIdParam.includes(pattern))
+
+            if (isMalformed) {
+                Utils.logWarn(`Detected malformed viewId in URL: ${viewIdParam}`)
+                history.replace('/error?id=unknown')
+                return
+            }
+        }
+    }, [match.params.boardId, match.params.viewId, history])
+
     // if we're in a legacy route and not showing a shared board,
     // redirect to the new URL schema equivalent
     if (Utils.isFocalboardLegacy() && !props.readonly) {

--- a/webapp/src/pages/boardPage/boardPage.tsx
+++ b/webapp/src/pages/boardPage/boardPage.tsx
@@ -291,20 +291,17 @@ const BoardPage = (props: Props): JSX.Element => {
     }, [])
 
     useEffect(() => {
-        if (isUrlMalformed) return
+        if (isUrlMalformed || !match.params.boardId) return
+
         dispatch(loadAction(match.params.boardId))
+        dispatch(setCurrentBoard(match.params.boardId))
 
-        if (match.params.boardId) {
-            // set the active board
-            dispatch(setCurrentBoard(match.params.boardId))
-
-            if (viewId !== Constants.globalTeamId) {
-                // reset current, even if empty string
-                dispatch(setCurrentView(viewId))
-                if (viewId) {
-                    // don't reset per board if empty string
-                    UserSettings.setLastViewId(match.params.boardId, viewId)
-                }
+        if (viewId !== Constants.globalTeamId) {
+            // reset current, even if empty string
+            dispatch(setCurrentView(viewId))
+            if (viewId) {
+                // don't reset per board if empty string
+                UserSettings.setLastViewId(match.params.boardId, viewId)
             }
         }
     }, [teamId, match.params.boardId, viewId, me?.id, isUrlMalformed])

--- a/webapp/src/pages/boardPage/teamToBoardAndViewRedirect.tsx
+++ b/webapp/src/pages/boardPage/teamToBoardAndViewRedirect.tsx
@@ -22,12 +22,13 @@ const TeamToBoardAndViewRedirect = (): null => {
     const boards = useAppSelector(getBoards)
     const teamId = match.params.teamId || UserSettings.lastTeamId || Constants.globalTeamId
 
-    // Cleanup: Remove skipRedirect flag when component unmounts
+    // Clear skip flag once the URL includes a boardId. The component stays mounted when
+    // navigating from /team/:teamId to /team/:teamId/:boardId, so unmount cleanup would not run.
     useEffect(() => {
-        return () => {
+        if (match.params.boardId) {
             sessionStorage.removeItem(Constants.sessionStorageSkipBoardRedirectKey)
         }
-    }, [])
+    }, [match.params.boardId])
 
     useEffect(() => {
         let boardID = match.params.boardId

--- a/webapp/src/pages/boardPage/teamToBoardAndViewRedirect.tsx
+++ b/webapp/src/pages/boardPage/teamToBoardAndViewRedirect.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {useEffect, useRef} from 'react'
+import {useEffect} from 'react'
 import {generatePath, useHistory, useRouteMatch} from 'react-router-dom'
 
 import {getBoards, getCurrentBoardId} from '../../store/boards'
@@ -22,23 +22,22 @@ const TeamToBoardAndViewRedirect = (): null => {
     const boards = useAppSelector(getBoards)
     const teamId = match.params.teamId || UserSettings.lastTeamId || Constants.globalTeamId
 
-    // Use ref to persist ignore flag across re-renders
-    const ignoreStoredUrlsRef = useRef<boolean>(false)
-
+    // Cleanup: Remove skipRedirect flag when component unmounts
     useEffect(() => {
-        const ignoreFlag = sessionStorage.getItem(Constants.sessionStorageIgnoreStoredUrlsKey) === 'true'
-        ignoreStoredUrlsRef.current = ignoreFlag
-
-        if (ignoreFlag) {
-            sessionStorage.removeItem(Constants.sessionStorageIgnoreStoredUrlsKey)
+        return () => {
+            sessionStorage.removeItem(Constants.sessionStorageSkipBoardRedirectKey)
         }
     }, [])
 
     useEffect(() => {
         let boardID = match.params.boardId
+
+        // Check if we should skip all auto-redirects (e.g., after error page)
+        const skipRedirect = sessionStorage.getItem(Constants.sessionStorageSkipBoardRedirectKey) === 'true'
+
         if (!match.params.boardId) {
-            // Skip auto-redirect if flag was set on mount
-            if (ignoreStoredUrlsRef.current) {
+            // Skip auto-redirect if flag is set
+            if (skipRedirect) {
                 return
             }
 
@@ -81,9 +80,7 @@ const TeamToBoardAndViewRedirect = (): null => {
         // when a view isn't open,
         // but the data is available, try opening a view
         if ((!viewID || viewID === '0') && boardId && boardId === match.params.boardId && boardViews && boardViews.length > 0) {
-            if (!ignoreStoredUrlsRef.current) {
-                viewID = UserSettings.lastViewId[boardID]
-            }
+            viewID = UserSettings.lastViewId[boardID]
             if (viewID) {
                 UserSettings.setLastViewId(boardID, viewID)
                 dispatch(setCurrentView(viewID))

--- a/webapp/src/pages/boardPage/teamToBoardAndViewRedirect.tsx
+++ b/webapp/src/pages/boardPage/teamToBoardAndViewRedirect.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {useEffect} from 'react'
+import {useEffect, useRef} from 'react'
 import {generatePath, useHistory, useRouteMatch} from 'react-router-dom'
 
 import {getBoards, getCurrentBoardId} from '../../store/boards'
@@ -22,9 +22,26 @@ const TeamToBoardAndViewRedirect = (): null => {
     const boards = useAppSelector(getBoards)
     const teamId = match.params.teamId || UserSettings.lastTeamId || Constants.globalTeamId
 
+    // Use ref to persist ignore flag across re-renders
+    const ignoreStoredUrlsRef = useRef<boolean>(false)
+
+    useEffect(() => {
+        const ignoreFlag = sessionStorage.getItem(Constants.sessionStorageIgnoreStoredUrlsKey) === 'true'
+        ignoreStoredUrlsRef.current = ignoreFlag
+
+        if (ignoreFlag) {
+            sessionStorage.removeItem(Constants.sessionStorageIgnoreStoredUrlsKey)
+        }
+    }, [])
+
     useEffect(() => {
         let boardID = match.params.boardId
         if (!match.params.boardId) {
+            // Skip auto-redirect if flag was set on mount
+            if (ignoreStoredUrlsRef.current) {
+                return
+            }
+
             // first preference is for last visited board
             boardID = UserSettings.lastBoardId[teamId]
 
@@ -64,8 +81,9 @@ const TeamToBoardAndViewRedirect = (): null => {
         // when a view isn't open,
         // but the data is available, try opening a view
         if ((!viewID || viewID === '0') && boardId && boardId === match.params.boardId && boardViews && boardViews.length > 0) {
-            // most recent view gets the first preference
-            viewID = UserSettings.lastViewId[boardID]
+            if (!ignoreStoredUrlsRef.current) {
+                viewID = UserSettings.lastViewId[boardID]
+            }
             if (viewID) {
                 UserSettings.setLastViewId(boardID, viewID)
                 dispatch(setCurrentView(viewID))

--- a/webapp/src/pages/errorPage.tsx
+++ b/webapp/src/pages/errorPage.tsx
@@ -28,13 +28,11 @@ const ErrorPage = () => {
             url = path as string
         }
 
-        // Clear stored URLs and set flag to prevent auto-redirect to broken boards
+        // Clear stored board/view IDs and set flag to skip all auto-redirects
         if (clearHistory) {
             localStorage.removeItem(UserSettingKey.LastBoardId)
             localStorage.removeItem(UserSettingKey.LastViewId)
-            sessionStorage.setItem(Constants.sessionStorageIgnoreStoredUrlsKey, 'true')
-            sessionStorage.removeItem(Constants.sessionStorageErrorRedirectCountKey)
-            sessionStorage.removeItem(Constants.sessionStorageErrorRedirectTimeKey)
+            sessionStorage.setItem(Constants.sessionStorageSkipBoardRedirectKey, 'true')
         }
 
         const finalUrl = clearHistory ? Utils.getFrontendBaseURL(true) : url

--- a/webapp/src/pages/errorPage.tsx
+++ b/webapp/src/pages/errorPage.tsx
@@ -12,6 +12,8 @@ import './errorPage.scss'
 
 import {errorDefFromId, ErrorId} from '../errors'
 import {Utils} from '../utils'
+import {UserSettingKey} from '../userSettings'
+import {Constants} from '../constants'
 
 const ErrorPage = () => {
     const history = useHistory()
@@ -19,27 +21,38 @@ const ErrorPage = () => {
     const errid = queryParams.get('id')
     const errorDef = errorDefFromId(errid as ErrorId)
 
-    const handleButtonClick = useCallback((path: string | ((params: URLSearchParams) => string)) => {
+    const handleButtonClick = useCallback((path: string | ((params: URLSearchParams) => string), clearHistory: boolean) => {
         let url = '/'
         if (typeof path === 'function') {
             url = path(queryParams)
         } else if (path) {
             url = path as string
         }
-        if (url === window.location.origin) {
-            window.location.href = url
+
+        // Clear stored URLs and set flag to prevent auto-redirect to broken boards
+        if (clearHistory) {
+            localStorage.removeItem(UserSettingKey.LastBoardId)
+            localStorage.removeItem(UserSettingKey.LastViewId)
+            sessionStorage.setItem(Constants.sessionStorageIgnoreStoredUrlsKey, 'true')
+            sessionStorage.removeItem(Constants.sessionStorageErrorRedirectCountKey)
+            sessionStorage.removeItem(Constants.sessionStorageErrorRedirectTimeKey)
+        }
+
+        if (url === window.location.origin || clearHistory) {
+            const finalUrl = clearHistory ? Utils.getFrontendBaseURL(true) : url
+            window.location.href = finalUrl
         } else {
             history.push(url)
         }
-    }, [history])
+    }, [history, queryParams])
 
-    const makeButton = ((path: string | ((params: URLSearchParams) => string), txt: string, fill: boolean) => {
+    const makeButton = ((path: string | ((params: URLSearchParams) => string), txt: string, fill: boolean, clearHistory: boolean) => {
         return (
             <Button
                 filled={fill}
                 size='large'
                 onClick={async () => {
-                    handleButtonClick(path)
+                    handleButtonClick(path, clearHistory)
                 }}
             >
                 {txt}
@@ -48,7 +61,7 @@ const ErrorPage = () => {
     })
 
     if (!Utils.isFocalboardPlugin() && errid === ErrorId.NotLoggedIn) {
-        handleButtonClick(errorDef.button1Redirect)
+        handleButtonClick(errorDef.button1Redirect, errorDef.button1ClearHistory)
     }
 
     return (
@@ -66,10 +79,10 @@ const ErrorPage = () => {
                 <ErrorIllustration/>
                 <br/>
                 {
-                    (errorDef.button1Enabled ? makeButton(errorDef.button1Redirect, errorDef.button1Text, errorDef.button1Fill) : null)
+                    (errorDef.button1Enabled ? makeButton(errorDef.button1Redirect, errorDef.button1Text, errorDef.button1Fill, errorDef.button1ClearHistory) : null)
                 }
                 {
-                    (errorDef.button2Enabled ? makeButton(errorDef.button2Redirect, errorDef.button2Text, errorDef.button2Fill) : null)
+                    (errorDef.button2Enabled ? makeButton(errorDef.button2Redirect, errorDef.button2Text, errorDef.button2Fill, errorDef.button2ClearHistory) : null)
                 }
             </div>
         </div>

--- a/webapp/src/pages/errorPage.tsx
+++ b/webapp/src/pages/errorPage.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {useCallback} from 'react'
-import {useHistory, useLocation} from 'react-router-dom'
+import {useLocation} from 'react-router-dom'
 import {FormattedMessage} from 'react-intl'
 
 import ErrorIllustration from '../svg/error-illustration'
@@ -16,7 +16,6 @@ import {UserSettingKey} from '../userSettings'
 import {Constants} from '../constants'
 
 const ErrorPage = () => {
-    const history = useHistory()
     const queryParams = new URLSearchParams(useLocation().search)
     const errid = queryParams.get('id')
     const errorDef = errorDefFromId(errid as ErrorId)
@@ -38,13 +37,9 @@ const ErrorPage = () => {
             sessionStorage.removeItem(Constants.sessionStorageErrorRedirectTimeKey)
         }
 
-        if (url === window.location.origin || clearHistory) {
-            const finalUrl = clearHistory ? Utils.getFrontendBaseURL(true) : url
-            window.location.href = finalUrl
-        } else {
-            history.push(url)
-        }
-    }, [history, queryParams])
+        const finalUrl = clearHistory ? Utils.getFrontendBaseURL(true) : url
+        window.location.href = finalUrl
+    }, [queryParams])
 
     const makeButton = ((path: string | ((params: URLSearchParams) => string), txt: string, fill: boolean, clearHistory: boolean) => {
         return (

--- a/webapp/src/router.tsx
+++ b/webapp/src/router.tsx
@@ -27,6 +27,7 @@ import {getFirstTeam, fetchTeams, Team} from './store/teams'
 import {getSidebarCategories, CategoryBoards} from './store/sidebar'
 import {getMySortedBoards} from './store/boards'
 import {UserSettings} from './userSettings'
+import {Constants} from './constants'
 import FBRoute from './route'
 
 declare let window: IAppWindow
@@ -91,6 +92,12 @@ function HomeToCurrentTeam(props: {path: string, exact: boolean}) {
                 }
 
                 const validBoardIds = new Set(myBoards.filter((b) => !b.deleteAt).map((b) => b.id))
+
+                // Check if we should skip auto-redirect (e.g., after error page cleared history)
+                const ignoreStoredUrls = sessionStorage.getItem(Constants.sessionStorageIgnoreStoredUrlsKey) === 'true'
+                if (ignoreStoredUrls) {
+                    return <Redirect to={`/team/${teamID}`}/>
+                }
 
                 if (UserSettings.lastBoardId) {
                     const lastBoardID = UserSettings.lastBoardId[teamID]

--- a/webapp/src/router.tsx
+++ b/webapp/src/router.tsx
@@ -27,7 +27,6 @@ import {getFirstTeam, fetchTeams, Team} from './store/teams'
 import {getSidebarCategories, CategoryBoards} from './store/sidebar'
 import {getMySortedBoards} from './store/boards'
 import {UserSettings} from './userSettings'
-import {Constants} from './constants'
 import FBRoute from './route'
 
 declare let window: IAppWindow
@@ -92,12 +91,6 @@ function HomeToCurrentTeam(props: {path: string, exact: boolean}) {
                 }
 
                 const validBoardIds = new Set(myBoards.filter((b) => !b.deleteAt).map((b) => b.id))
-
-                // Check if we should skip auto-redirect (e.g., after error page cleared history)
-                const ignoreStoredUrls = sessionStorage.getItem(Constants.sessionStorageIgnoreStoredUrlsKey) === 'true'
-                if (ignoreStoredUrls) {
-                    return <Redirect to={`/team/${teamID}`}/>
-                }
 
                 if (UserSettings.lastBoardId) {
                     const lastBoardID = UserSettings.lastBoardId[teamID]

--- a/webapp/src/router.tsx
+++ b/webapp/src/router.tsx
@@ -97,7 +97,7 @@ function HomeToCurrentTeam(props: {path: string, exact: boolean}) {
                     const lastViewID = UserSettings.lastViewId[lastBoardID]
 
                     if (lastBoardID) {
-                        if (!validBoardIds.has(lastBoardID)) {
+                        if (validBoardIds.size > 0 && !validBoardIds.has(lastBoardID)) {
                             let fallbackBoardId: string | null = null
                             for (const category of categories) {
                                 const visible = category.boardMetadata.find((m) => !m.hidden && validBoardIds.has(m.boardID))


### PR DESCRIPTION
#### Summary
The PR Fix the infinite redirect loop for boards. 

### Findings on the Infinite Redirect Issue for Boards

While trying to reproduce the infinite redirect issue in Boards, I noticed a pattern related to URLs that end with `/error`.
When the page is reloaded while the URL contains `/error`, the following sequence happens:

- Initial URL
Example URL:
```
http://localhost:8065/boards/team/<teamId>/<boardId>/<viewId>/error
```

- Error boundary triggers
The application error boundary catches an error and runs this redirect:
```
window.location.replace('plugins/focalboard/error?id=unknown')
```

- Browser treats the redirect as a relative path
Since the path doesn’t start with /, the browser appends it to the current URL instead of treating it as a root path.
So the new URL becomes:
```
http://localhost:8065/boards/team/<teamId>/<boardId>/<viewId>/plugins/focalboard/error?id=unknown
```

- Route mismatch happens
This new URL does not match the `/error` route, so the app loads BoardPage (or a similar route) with incorrect parameters.

-  Another error is triggered
BoardPage fails again, which causes:
  - another error
  - the error boundary to run again
  - another redirect


-  URL keeps growing
Each redirect appends more segments to the path, such as:
```
.../plugins/focalboard/error
.../boards/error
.../boards/plugins/focalboard/error
```
This creates the infinite redirect loop.

#### Why the error boundary kept triggering
Routes like:
```
/boards/team/.../error
```

are matched by the BoardPage route:
```
/team/:teamId/:boardId?/:viewId?/:cardId?
```
In this case: cardId = "error"

BoardPage then tries to load a card with ID “error”, which does not exist.
This throws an error, which the error boundary catches again, restarting the same redirect process.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65641