### PR TITLE
Fix bot notification board link

### DIFF
--- a/server/app/boards.go
+++ b/server/app/boards.go
@@ -6,6 +6,7 @@ package app
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/mattermost/mattermost-plugin-boards/server/model"
 	"github.com/mattermost/mattermost-plugin-boards/server/services/notify"
@@ -359,7 +360,9 @@ func (a *App) PatchBoard(patch *model.BoardPatch, boardID, userID string) (*mode
 			username = user.Username
 		}
 
-		boardLink := utils.MakeBoardLink(a.config.ServerRoot, updatedBoard.TeamID, updatedBoard.ID)
+		// Use /boards path for channel notification links so boards open in-app (not in pop-up)
+		boardsRoot := strings.Replace(a.config.ServerRoot, "/plugins/focalboard", "/boards", 1)
+		boardLink := utils.MakeBoardLink(boardsRoot, updatedBoard.TeamID, updatedBoard.ID)
 		title := updatedBoard.Title
 		if title == "" {
 			title = "Untitled board" // todo: localize this when server has i18n

--- a/server/boards/boardsapp_util.go
+++ b/server/boards/boardsapp_util.go
@@ -80,7 +80,7 @@ func createBoardsConfig(mmconfig mm_model.Config, baseURL string, serverID strin
 		showFullName = *mmconfig.PrivacySettings.ShowFullName
 	}
 
-	serverRoot := baseURL + "/plugins/focalboard"
+	serverRoot := baseURL + "/boards"
 
 	return &config.Configuration{
 		ServerRoot:               serverRoot,

--- a/server/boards/boardsapp_util.go
+++ b/server/boards/boardsapp_util.go
@@ -80,7 +80,7 @@ func createBoardsConfig(mmconfig mm_model.Config, baseURL string, serverID strin
 		showFullName = *mmconfig.PrivacySettings.ShowFullName
 	}
 
-	serverRoot := baseURL + "/boards"
+	serverRoot := baseURL + "/plugins/focalboard"
 
 	return &config.Configuration{
 		ServerRoot:               serverRoot,


### PR DESCRIPTION
#### Summary
The issue was caused by how the board links were being generated in channel notifications.
Earlier, the ServerRoot was set to:
```
baseURL + "/plugins/focalboard"
```
Because of this, when users clicked on a board link in the desktop app, it opened in a pop-up window, and there was no easy way to go back to the channel.

After updating ServerRoot to:

```
baseURL + "/boards"
```
The behaviour is now correct:
	•	Boards open in the same window
	•	Users can easily switch back to the channel

So, the root cause was using the wrong base path for board links.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67948


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Reasoning:** This is a highly isolated change affecting only the board link construction in channel notification messages within the `PatchBoard` function. The modification simply replaces the ServerRoot path from `/plugins/focalboard` to `/boards` before generating the notification link, which is a straightforward string operation with no side effects on core functionality or data persistence.

**Regression Risk:** Minimal. The change is surgically isolated to notification link formatting and does not affect the core `PatchBoard` logic, database operations, or business workflows. The `MakeBoardLink` utility function remains unmodified, and the `strings.Replace` operation with a limit of 1 is safe and deterministic. The `PatchBoard` function has existing unit test coverage in `server/app/boards_test.go`, though the notification message generation itself is not explicitly tested in mocked tests.

**QA Recommendation:** Light manual QA is recommended—verify that board link/unlink notifications in channels display correct URLs and that clicking links opens boards in-app rather than in a popup window. Existing automated regression tests of the `PatchBoard` unit tests are sufficient to catch any side effects. Low risk to skip comprehensive manual QA given the isolated scope and straightforward nature of the change (only a URL transformation in notification messages).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->