### PR TITLE
Fixed Webapp test for boards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,22 +16,21 @@ permissions:
   contents: read
 
 jobs:
-  # TODO: re-enable webapp-test in a follow-up PR
-  # webapp-test:
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-  #     with:
-  #       path: "focalboard"
-  #   - name: Setup Node
-  #     uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-  #     with:
-  #       node-version-file: focalboard/.nvmrc
-  #   - name: npm ci
-  #     run: cd focalboard/webapp && npm ci
-  #   - name: Lint & test webapp
-  #     run: cd focalboard; make webapp-ci
+  webapp-test:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        path: "focalboard"
+    - name: Setup Node
+      uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+      with:
+        node-version-file: focalboard/.nvmrc
+    - name: npm ci
+      run: cd focalboard/webapp && npm ci
+    - name: Lint & test webapp
+      run: cd focalboard; make webapp-ci
 
   server-test:
     runs-on: ubuntu-22.04

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -92,6 +92,9 @@
 		],
 		"setupFiles": [
 			"./tests/setupFile.ts"
+		],
+		"testPathIgnorePatterns": [
+			"<rootDir>/dist/"
 		]
 	},
 	"devDependencies": {

--- a/webapp/src/components/__snapshots__/cardDialog.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/cardDialog.test.tsx.snap
@@ -157,7 +157,13 @@ exports[`components/cardDialog already following card 1`] = `
                 <div
                   class="octo-editor-preview octo-placeholder"
                   data-testid="preview-element"
-                />
+                >
+                  <div
+                    class="mocked-message-html"
+                  >
+                    Test Comment
+                  </div>
+                </div>
               </div>
               
             </div>
@@ -184,7 +190,13 @@ exports[`components/cardDialog already following card 1`] = `
                 <div
                   class="octo-editor-preview octo-placeholder"
                   data-testid="preview-element"
-                />
+                >
+                  <div
+                    class="mocked-message-html"
+                  >
+                    Test Comment
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -883,7 +895,13 @@ exports[`components/cardDialog return cardDialog menu content 1`] = `
                 <div
                   class="octo-editor-preview octo-placeholder"
                   data-testid="preview-element"
-                />
+                >
+                  <div
+                    class="mocked-message-html"
+                  >
+                    Test Comment
+                  </div>
+                </div>
               </div>
               
             </div>
@@ -910,7 +928,13 @@ exports[`components/cardDialog return cardDialog menu content 1`] = `
                 <div
                   class="octo-editor-preview octo-placeholder"
                   data-testid="preview-element"
-                />
+                >
+                  <div
+                    class="mocked-message-html"
+                  >
+                    Test Comment
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -1095,7 +1119,13 @@ exports[`components/cardDialog return cardDialog menu content and cancel delete 
                 <div
                   class="octo-editor-preview octo-placeholder"
                   data-testid="preview-element"
-                />
+                >
+                  <div
+                    class="mocked-message-html"
+                  >
+                    Test Comment
+                  </div>
+                </div>
               </div>
               
             </div>
@@ -1122,7 +1152,13 @@ exports[`components/cardDialog return cardDialog menu content and cancel delete 
                 <div
                   class="octo-editor-preview octo-placeholder"
                   data-testid="preview-element"
-                />
+                >
+                  <div
+                    class="mocked-message-html"
+                  >
+                    Test Comment
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -1307,7 +1343,13 @@ exports[`components/cardDialog should match snapshot 1`] = `
                 <div
                   class="octo-editor-preview octo-placeholder"
                   data-testid="preview-element"
-                />
+                >
+                  <div
+                    class="mocked-message-html"
+                  >
+                    Test Comment
+                  </div>
+                </div>
               </div>
               
             </div>
@@ -1334,7 +1376,13 @@ exports[`components/cardDialog should match snapshot 1`] = `
                 <div
                   class="octo-editor-preview octo-placeholder"
                   data-testid="preview-element"
-                />
+                >
+                  <div
+                    class="mocked-message-html"
+                  >
+                    Test Comment
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/webapp/src/components/__snapshots__/centerPanel.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/centerPanel.test.tsx.snap
@@ -87,7 +87,13 @@ exports[`components/centerPanel Clicking on the Hidden card count should open a 
               <div
                 class="octo-editor-preview"
                 data-testid="preview-element"
-              />
+              >
+                <div
+                  class="mocked-message-html"
+                >
+                  Test Comment
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -795,7 +801,13 @@ exports[`components/centerPanel return centerPanel and click on card to show car
               <div
                 class="octo-editor-preview"
                 data-testid="preview-element"
-              />
+              >
+                <div
+                  class="mocked-message-html"
+                >
+                  Test Comment
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -1348,7 +1360,13 @@ exports[`components/centerPanel return centerPanel and click on new card to edit
               <div
                 class="octo-editor-preview"
                 data-testid="preview-element"
-              />
+              >
+                <div
+                  class="mocked-message-html"
+                >
+                  Test Comment
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -1989,7 +2007,13 @@ exports[`components/centerPanel return centerPanel and press touch 1 with readon
               <div
                 class="octo-editor-preview"
                 data-testid="preview-element"
-              />
+              >
+                <div
+                  class="mocked-message-html"
+                >
+                  Test Comment
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -2405,7 +2429,13 @@ exports[`components/centerPanel return centerPanel and press touch ctrl+d for on
               <div
                 class="octo-editor-preview"
                 data-testid="preview-element"
-              />
+              >
+                <div
+                  class="mocked-message-html"
+                >
+                  Test Comment
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -3063,7 +3093,13 @@ exports[`components/centerPanel return centerPanel and press touch del for one c
               <div
                 class="octo-editor-preview"
                 data-testid="preview-element"
-              />
+              >
+                <div
+                  class="mocked-message-html"
+                >
+                  Test Comment
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -3721,7 +3757,13 @@ exports[`components/centerPanel return centerPanel and press touch esc for one c
               <div
                 class="octo-editor-preview"
                 data-testid="preview-element"
-              />
+              >
+                <div
+                  class="mocked-message-html"
+                >
+                  Test Comment
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -4379,7 +4421,13 @@ exports[`components/centerPanel return centerPanel and press touch esc for one c
               <div
                 class="octo-editor-preview"
                 data-testid="preview-element"
-              />
+              >
+                <div
+                  class="mocked-message-html"
+                >
+                  Test Comment
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -5037,7 +5085,13 @@ exports[`components/centerPanel return centerPanel and press touch esc for two c
               <div
                 class="octo-editor-preview"
                 data-testid="preview-element"
-              />
+              >
+                <div
+                  class="mocked-message-html"
+                >
+                  Test Comment
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -5695,7 +5749,13 @@ exports[`components/centerPanel return centerPanel and press touch esc for two c
               <div
                 class="octo-editor-preview"
                 data-testid="preview-element"
-              />
+              >
+                <div
+                  class="mocked-message-html"
+                >
+                  Test Comment
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -6353,7 +6413,13 @@ exports[`components/centerPanel return centerPanel and press touch esc for two c
               <div
                 class="octo-editor-preview"
                 data-testid="preview-element"
-              />
+              >
+                <div
+                  class="mocked-message-html"
+                >
+                  Test Comment
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -7011,7 +7077,13 @@ exports[`components/centerPanel return centerPanel and select one card and click
               <div
                 class="octo-editor-preview"
                 data-testid="preview-element"
-              />
+              >
+                <div
+                  class="mocked-message-html"
+                >
+                  Test Comment
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -7669,7 +7741,13 @@ exports[`components/centerPanel return centerPanel and select one card and click
               <div
                 class="octo-editor-preview"
                 data-testid="preview-element"
-              />
+              >
+                <div
+                  class="mocked-message-html"
+                >
+                  Test Comment
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -8327,7 +8405,13 @@ exports[`components/centerPanel should match snapshot for Gallery 1`] = `
               <div
                 class="octo-editor-preview"
                 data-testid="preview-element"
-              />
+              >
+                <div
+                  class="mocked-message-html"
+                >
+                  Test Comment
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -8602,7 +8686,13 @@ exports[`components/centerPanel should match snapshot for Kanban 1`] = `
               <div
                 class="octo-editor-preview"
                 data-testid="preview-element"
-              />
+              >
+                <div
+                  class="mocked-message-html"
+                >
+                  Test Comment
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -9121,7 +9211,13 @@ exports[`components/centerPanel should match snapshot for Kanban, not shared 1`]
               <div
                 class="octo-editor-preview"
                 data-testid="preview-element"
-              />
+              >
+                <div
+                  class="mocked-message-html"
+                >
+                  Test Comment
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -9640,7 +9736,13 @@ exports[`components/centerPanel should match snapshot for Table 1`] = `
               <div
                 class="octo-editor-preview"
                 data-testid="preview-element"
-              />
+              >
+                <div
+                  class="mocked-message-html"
+                >
+                  Test Comment
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/webapp/src/components/__snapshots__/contentBlock.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/contentBlock.test.tsx.snap
@@ -481,7 +481,13 @@ exports[`components/contentBlock should match snapshot with textBlock 1`] = `
         <div
           class="octo-editor-preview"
           data-testid="preview-element"
-        />
+        >
+          <div
+            class="mocked-message-html"
+          >
+            Test Comment
+          </div>
+        </div>
       </div>
     </div>
     <div

--- a/webapp/src/components/__snapshots__/markdownEditor.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/markdownEditor.test.tsx.snap
@@ -8,7 +8,13 @@ exports[`components/markdownEditor should match snapshot 1`] = `
     <div
       class="octo-editor-preview octo-placeholder"
       data-testid="preview-element"
-    />
+    >
+      <div
+        class="mocked-message-html"
+      >
+        Test Comment
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -21,7 +27,13 @@ exports[`components/markdownEditor should match snapshot with initial text 1`] =
     <div
       class="octo-editor-preview"
       data-testid="preview-element"
-    />
+    >
+      <div
+        class="mocked-message-html"
+      >
+        Test Comment
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/webapp/src/components/__snapshots__/viewTitle.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/viewTitle.test.tsx.snap
@@ -151,7 +151,13 @@ exports[`components/viewTitle should match snapshot 1`] = `
         <div
           class="octo-editor-preview"
           data-testid="preview-element"
-        />
+        >
+          <div
+            class="mocked-message-html"
+          >
+            Test Comment
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -198,7 +204,13 @@ exports[`components/viewTitle should match snapshot readonly 1`] = `
         <div
           class="octo-editor-preview"
           data-testid="preview-element"
-        />
+        >
+          <div
+            class="mocked-message-html"
+          >
+            Test Comment
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -261,7 +273,13 @@ exports[`components/viewTitle show description 1`] = `
         <div
           class="octo-editor-preview"
           data-testid="preview-element"
-        />
+        >
+          <div
+            class="mocked-message-html"
+          >
+            Test Comment
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/webapp/src/components/__snapshots__/workspace.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/workspace.test.tsx.snap
@@ -346,7 +346,13 @@ exports[`src/components/workspace return workspace and showcard 1`] = `
                   <div
                     class="octo-editor-preview"
                     data-testid="preview-element"
-                  />
+                  >
+                    <div
+                      class="mocked-message-html"
+                    >
+                      Test Comment
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
@@ -868,7 +874,13 @@ exports[`src/components/workspace return workspace readonly and showcard 1`] = `
                   <div
                     class="octo-editor-preview"
                     data-testid="preview-element"
-                  />
+                  >
+                    <div
+                      class="mocked-message-html"
+                    >
+                      Test Comment
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
@@ -1457,7 +1469,13 @@ exports[`src/components/workspace should match snapshot 1`] = `
                   <div
                     class="octo-editor-preview"
                     data-testid="preview-element"
-                  />
+                  >
+                    <div
+                      class="mocked-message-html"
+                    >
+                      Test Comment
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
@@ -1979,7 +1997,13 @@ exports[`src/components/workspace should match snapshot with readonly 1`] = `
                   <div
                     class="octo-editor-preview"
                     data-testid="preview-element"
-                  />
+                  >
+                    <div
+                      class="mocked-message-html"
+                    >
+                      Test Comment
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/webapp/src/components/blocksEditor/__snapshots__/blocksEditor.test.tsx.snap
+++ b/webapp/src/components/blocksEditor/__snapshots__/blocksEditor.test.tsx.snap
@@ -14,7 +14,18 @@ exports[`components/blocksEditor/blocksEditor should match snapshot on empty 1`]
         <span
           class="css-1f43avz-a11yText-A11yText"
           id="react-select-2-live-region"
-        />
+        >
+          <span
+            id="aria-selection"
+          >
+            option , selected.
+          </span>
+          <span
+            id="aria-context"
+          >
+              Select is focused ,type to refine list, press Down to open the menu, 
+          </span>
+        </span>
         <span
           aria-atomic="false"
           aria-live="polite"
@@ -22,7 +33,7 @@ exports[`components/blocksEditor/blocksEditor should match snapshot on empty 1`]
           class="css-1f43avz-a11yText-A11yText"
         />
         <div
-          class=" css-1haocjs-control"
+          class=" css-a5687m-control"
         >
           <div
             class=" css-b2z5qd-ValueContainer"
@@ -394,7 +405,18 @@ exports[`components/blocksEditor/blocksEditor should match snapshot with blocks 
         <span
           class="css-1f43avz-a11yText-A11yText"
           id="react-select-3-live-region"
-        />
+        >
+          <span
+            id="aria-selection"
+          >
+            option , selected.
+          </span>
+          <span
+            id="aria-context"
+          >
+              Select is focused ,type to refine list, press Down to open the menu, 
+          </span>
+        </span>
         <span
           aria-atomic="false"
           aria-live="polite"
@@ -402,7 +424,7 @@ exports[`components/blocksEditor/blocksEditor should match snapshot with blocks 
           class="css-1f43avz-a11yText-A11yText"
         />
         <div
-          class=" css-1haocjs-control"
+          class=" css-a5687m-control"
         >
           <div
             class=" css-b2z5qd-ValueContainer"

--- a/webapp/src/components/blocksEditor/__snapshots__/editor.test.tsx.snap
+++ b/webapp/src/components/blocksEditor/__snapshots__/editor.test.tsx.snap
@@ -76,7 +76,18 @@ exports[`components/blocksEditor/editor should match snapshot on empty 1`] = `
       <span
         class="css-1f43avz-a11yText-A11yText"
         id="react-select-2-live-region"
-      />
+      >
+        <span
+          id="aria-selection"
+        >
+          option , selected.
+        </span>
+        <span
+          id="aria-context"
+        >
+            Select is focused ,type to refine list, press Down to open the menu, 
+        </span>
+      </span>
       <span
         aria-atomic="false"
         aria-live="polite"
@@ -84,7 +95,7 @@ exports[`components/blocksEditor/editor should match snapshot on empty 1`] = `
         class="css-1f43avz-a11yText-A11yText"
       />
       <div
-        class=" css-1haocjs-control"
+        class=" css-a5687m-control"
       >
         <div
           class=" css-b2z5qd-ValueContainer"

--- a/webapp/src/components/blocksEditor/__snapshots__/rootInput.test.tsx.snap
+++ b/webapp/src/components/blocksEditor/__snapshots__/rootInput.test.tsx.snap
@@ -8,7 +8,18 @@ exports[`components/blocksEditor/rootInput should match Display snapshot 1`] = `
     <span
       class="css-1f43avz-a11yText-A11yText"
       id="react-select-2-live-region"
-    />
+    >
+      <span
+        id="aria-selection"
+      >
+        option , selected.
+      </span>
+      <span
+        id="aria-context"
+      >
+          Select is focused ,type to refine list, press Down to open the menu, 
+      </span>
+    </span>
     <span
       aria-atomic="false"
       aria-live="polite"
@@ -16,7 +27,7 @@ exports[`components/blocksEditor/rootInput should match Display snapshot 1`] = `
       class="css-1f43avz-a11yText-A11yText"
     />
     <div
-      class=" css-1haocjs-control"
+      class=" css-a5687m-control"
     >
       <div
         class=" css-b2z5qd-ValueContainer"
@@ -60,7 +71,18 @@ exports[`components/blocksEditor/rootInput should match Input snapshot 1`] = `
     <span
       class="css-1f43avz-a11yText-A11yText"
       id="react-select-3-live-region"
-    />
+    >
+      <span
+        id="aria-selection"
+      >
+        option , selected.
+      </span>
+      <span
+        id="aria-context"
+      >
+          Select is focused ,type to refine list, press Down to open the menu, 
+      </span>
+    </span>
     <span
       aria-atomic="false"
       aria-live="polite"
@@ -68,7 +90,7 @@ exports[`components/blocksEditor/rootInput should match Input snapshot 1`] = `
       class="css-1f43avz-a11yText-A11yText"
     />
     <div
-      class=" css-1haocjs-control"
+      class=" css-a5687m-control"
     >
       <div
         class=" css-b2z5qd-ValueContainer"
@@ -118,9 +140,18 @@ exports[`components/blocksEditor/rootInput should match Input snapshot with menu
       aria-live="polite"
       aria-relevant="additions text"
       class="css-1f43avz-a11yText-A11yText"
-    />
+    >
+      <span
+        id="aria-selection"
+      />
+      <span
+        id="aria-context"
+      >
+        option /title Creates a new Title block. focused, 1 of 11. 11 results available. Use Up and Down to choose options, press Enter to select the currently focused option, press Escape to exit the menu, press Tab to select the option and exit the menu.
+      </span>
+    </span>
     <div
-      class=" css-1haocjs-control"
+      class=" css-a5687m-control"
     >
       <div
         class=" css-b2z5qd-ValueContainer"

--- a/webapp/src/components/blocksEditor/blocks/text/text.test.tsx
+++ b/webapp/src/components/blocksEditor/blocks/text/text.test.tsx
@@ -38,6 +38,11 @@ describe('components/blocksEditor/blocks/text', () => {
         clientConfig: {
             value: {},
         },
+        teams: {
+            current: null,
+            currentId: '',
+            allTeams: [],
+        },
     }
     const store = mockStateStore([], state)
 

--- a/webapp/src/components/blocksEditor/editor.test.tsx
+++ b/webapp/src/components/blocksEditor/editor.test.tsx
@@ -38,6 +38,11 @@ describe('components/blocksEditor/editor', () => {
         clientConfig: {
             value: {},
         },
+        teams: {
+            current: null,
+            currentId: '',
+            allTeams: [],
+        },
     }
     const store = mockStateStore([], state)
 

--- a/webapp/src/components/cardDetail/__snapshots__/cardDetailContents.test.tsx.snap
+++ b/webapp/src/components/cardDetail/__snapshots__/cardDetailContents.test.tsx.snap
@@ -18,9 +18,11 @@ exports[`components/cardDetail/cardDetailContents should match snapshot 1`] = `
           class="octo-editor-preview octo-placeholder"
           data-testid="preview-element"
         >
-          <p>
-            Add a description...
-          </p>
+          <div
+            class="mocked-message-html"
+          >
+            Test Comment
+          </div>
         </div>
       </div>
     </div>

--- a/webapp/src/components/cardDetail/__snapshots__/commentsList.test.tsx.snap
+++ b/webapp/src/components/cardDetail/__snapshots__/commentsList.test.tsx.snap
@@ -19,9 +19,11 @@ exports[`components/cardDetail/CommentsList comments show up 1`] = `
           class="octo-editor-preview octo-placeholder"
           data-testid="preview-element"
         >
-          <p>
-            Add a comment...
-          </p>
+          <div
+            class="mocked-message-html"
+          >
+            Test Comment
+          </div>
         </div>
       </div>
       

--- a/webapp/src/components/cardDetail/cardDetail.test.tsx
+++ b/webapp/src/components/cardDetail/cardDetail.test.tsx
@@ -130,7 +130,7 @@ describe('components/cardDetail/CardDetail', () => {
         expect(container).toBeDefined()
 
         // Comments show up
-        const comments = container!.querySelectorAll('.mocked-message-html')
+        const comments = container!.querySelectorAll('.comment-markdown .mocked-message-html')
         expect(comments.length).toBe(2)
 
         // Add comment option visible when readonly mode is off
@@ -194,7 +194,7 @@ describe('components/cardDetail/CardDetail', () => {
         expect(container).toBeDefined()
 
         // comments show up
-        const comments = container!.querySelectorAll('.mocked-message-html')
+        const comments = container!.querySelectorAll('.comment-markdown .mocked-message-html')
         expect(comments.length).toBe(2)
 
         // Add comment option is not shown in readonly mode

--- a/webapp/src/components/cardDetail/cardDetailContents.test.tsx
+++ b/webapp/src/components/cardDetail/cardDetailContents.test.tsx
@@ -76,6 +76,11 @@ describe('components/cardDetail/cardDetailContents', () => {
         clientConfig: {
             value: {},
         },
+        teams: {
+            current: null,
+            currentId: '',
+            allTeams: [],
+        },
     }
     const store = mockStateStore([], state)
     const wrap = (child: ReactNode): ReactElement => (

--- a/webapp/src/components/cardDetail/commentsList.test.tsx
+++ b/webapp/src/components/cardDetail/commentsList.test.tsx
@@ -104,7 +104,7 @@ describe('components/cardDetail/CommentsList', () => {
         expect(container).toMatchSnapshot()
 
         // Comments show up
-        const comments = container!.querySelectorAll('.mocked-message-html')
+        const comments = container!.querySelectorAll('.comment-markdown .mocked-message-html')
         expect(comments.length).toBe(2)
 
         // Add comment option visible when readonly mode is off
@@ -163,7 +163,7 @@ describe('components/cardDetail/CommentsList', () => {
         expect(container).toMatchSnapshot()
 
         // Comments show up
-        const comments = container!.querySelectorAll('.mocked-message-html')
+        const comments = container!.querySelectorAll('.comment-markdown .mocked-message-html')
         expect(comments.length).toBe(2)
 
         // Add comment option visible when readonly mode is off

--- a/webapp/src/components/content/__snapshots__/textElement.test.tsx.snap
+++ b/webapp/src/components/content/__snapshots__/textElement.test.tsx.snap
@@ -8,7 +8,13 @@ exports[`components/content/TextElement return a textElement 1`] = `
     <div
       class="octo-editor-preview octo-placeholder"
       data-testid="preview-element"
-    />
+    >
+      <div
+        class="mocked-message-html"
+      >
+        Test Comment
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/webapp/src/components/content/textElement.test.tsx
+++ b/webapp/src/components/content/textElement.test.tsx
@@ -67,6 +67,11 @@ describe('components/content/TextElement', () => {
         clientConfig: {
             value: {},
         },
+        teams: {
+            current: null,
+            currentId: '',
+            allTeams: [],
+        },
     }
     const store = mockStateStore([], state)
 

--- a/webapp/src/components/contentBlock.test.tsx
+++ b/webapp/src/components/contentBlock.test.tsx
@@ -88,6 +88,11 @@ describe('components/contentBlock', () => {
         clientConfig: {
             value: {},
         },
+        teams: {
+            current: null,
+            currentId: '',
+            allTeams: [],
+        },
     }
     const store = mockStateStore([], state)
 

--- a/webapp/src/components/globalHeader/__snapshots__/globalHeader.test.tsx.snap
+++ b/webapp/src/components/globalHeader/__snapshots__/globalHeader.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`components/sidebar/GlobalHeader header menu should match snapshot 1`] =
     />
     <a
       class="GlobalHeaderComponent__button help-button"
-      href="https://www.focalboard.com/fwlink/doc-boards.html?v=9.2.2"
+      href="https://www.focalboard.com/fwlink/doc-boards.html?v=0.0.0"
       rel="noreferrer"
       target="_blank"
     >

--- a/webapp/src/components/markdownEditor.test.tsx
+++ b/webapp/src/components/markdownEditor.test.tsx
@@ -42,6 +42,11 @@ describe('components/markdownEditor', () => {
         clientConfig: {
             value: {},
         },
+        teams: {
+            current: null,
+            currentId: '',
+            allTeams: [],
+        },
     }
     const store = mockStateStore([], state)
     test('should match snapshot', async () => {

--- a/webapp/src/components/markdownEditor.tsx
+++ b/webapp/src/components/markdownEditor.tsx
@@ -39,10 +39,11 @@ const MarkdownEditor = (props: Props): JSX.Element => {
 
     const selectedTeam = useAppSelector(getCurrentTeam)
     const channelNamesMap = useMemo(() => {
-        if (!selectedTeam) {
+        const windowStore = (window as any).store
+        if (!selectedTeam || !windowStore) {
             return EMPTY_CHANNEL_NAMES_MAP
         }
-        return getChannelsNameMapInTeam((window as any).store.getState(), selectedTeam.id)
+        return getChannelsNameMapInTeam(windowStore.getState(), selectedTeam.id)
     }, [selectedTeam?.id])
 
     const previewElement = (

--- a/webapp/src/components/sidebar/__snapshots__/sidebar.test.tsx.snap
+++ b/webapp/src/components/sidebar/__snapshots__/sidebar.test.tsx.snap
@@ -51,9 +51,9 @@ exports[`components/sidebarSidebar dont show hidden boards 1`] = `
                   >
                     <div
                       class="version"
-                      title="v9.2.2"
+                      title="v0.0.0"
                     >
-                      v9.2.2
+                      v0.0.0
                     </div>
                   </div>
                 </div>
@@ -252,9 +252,9 @@ exports[`components/sidebarSidebar should assign default category if current boa
                   >
                     <div
                       class="version"
-                      title="v9.2.2"
+                      title="v0.0.0"
                     >
-                      v9.2.2
+                      v0.0.0
                     </div>
                   </div>
                 </div>
@@ -508,9 +508,9 @@ exports[`components/sidebarSidebar shouldnt do any category assignment is board 
                   >
                     <div
                       class="version"
-                      title="v9.2.2"
+                      title="v0.0.0"
                     >
-                      v9.2.2
+                      v0.0.0
                     </div>
                   </div>
                 </div>
@@ -919,9 +919,9 @@ exports[`components/sidebarSidebar sidebar hidden 1`] = `
                   >
                     <div
                       class="version"
-                      title="v9.2.2"
+                      title="v0.0.0"
                     >
-                      v9.2.2
+                      v0.0.0
                     </div>
                   </div>
                 </div>
@@ -1213,9 +1213,9 @@ exports[`components/sidebarSidebar some categories hidden 1`] = `
                   >
                     <div
                       class="version"
-                      title="v9.2.2"
+                      title="v0.0.0"
                     >
-                      v9.2.2
+                      v0.0.0
                     </div>
                   </div>
                 </div>

--- a/webapp/tests/mock_window.tsx
+++ b/webapp/tests/mock_window.tsx
@@ -58,7 +58,7 @@ export const mockMMStore = mockStore({
                 }),
             },
             channelsInTeam: {
-                'team-id': new Set(['asdf']),
+                'team-id': new Set(['current_channel_id']),
             },
             messageCounts: {
                 current_channel_id: {total: 10},

--- a/webapp/tests/setupFile.ts
+++ b/webapp/tests/setupFile.ts
@@ -4,6 +4,29 @@
 import React from 'react'
 import { jest } from '@jest/globals'
 
+// jsdom does not implement scrollIntoView — stub it out globally.
+window.HTMLElement.prototype.scrollIntoView = jest.fn()
+
+// Provide a minimal stub for the Mattermost webapp's global redux store,
+// which MarkdownEditor accesses via (window as any).store.getState() for
+// channel name mapping, and wraps content in a <Provider store={...}>.
+;(window as any).store = {
+    getState: () => ({
+        entities: {
+            channels: {
+                channels: {},
+                channelsInTeam: {},
+                myMembers: {},
+                stats: {},
+                messageCounts: {},
+                membersInChannel: {},
+            },
+        },
+    }),
+    subscribe: () => () => {},
+    dispatch: () => {},
+}
+
 jest.mock('../src/webapp_globals', () =>
     Object.assign({}, jest.requireActual('../src/webapp_globals'), {
         messageHtmlToComponent: jest.fn(() =>


### PR DESCRIPTION
#### Summary
Fixed all the webapp tests for boards, added the CI rule to run webapp test. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68079



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Medium risk with localized potential for regression. The changes primarily affect the webapp test suite, but several factors elevate the risk:
- Global test setup modifications in `setupFile.ts` add window-level mocks (`scrollIntoView`, `window.store`) that could have unexpected interactions with other tests
- The `teams` Redux slice is added to multiple test mocks, requiring consistent implementation across all affected test files to avoid state shape mismatches
- The `markdownEditor.tsx` refactoring modifies production code to handle `window.store` access, introducing a dependency on global state that could be fragile if the store isn't properly initialized
- Mock channel data changes (`mock_window.tsx`) affect the test fixture data structure, requiring validation that all dependent tests are aligned

**QA Recommendation:** Given that automated test coverage is being significantly expanded by enabling the previously disabled webapp-test CI job, manual QA can be minimized. However, focus manual testing on:
- Markdown editor rendering and team-aware channel selection functionality
- Redux state initialization in interactive components that depend on the teams slice
- Verify no regression in existing snapshot tests after the comment DOM selector refinements

The straightforward nature of test fixes and the fact that no critical business logic or data handling was modified keep this to medium risk rather than high.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->