### PR TITLE
Fix: Deleting the attachment from the card lead to error page

### DIFF
--- a/webapp/src/store/attachments.ts
+++ b/webapp/src/store/attachments.ts
@@ -46,7 +46,11 @@ const attachmentSlice = createSlice({
             }
         },
         updateUploadPrecent: (state, action: PayloadAction<{blockId: string, uploadPercent: number}>) => {
-            state.attachments[action.payload.blockId].uploadingPercent = action.payload.uploadPercent
+            const attachment = state.attachments[action.payload.blockId]
+            if (!attachment) {
+                return
+            }
+            attachment.uploadingPercent = action.payload.uploadPercent
         },
     },
     extraReducers: (builder) => {

--- a/webapp/src/store/attachments.ts
+++ b/webapp/src/store/attachments.ts
@@ -88,6 +88,6 @@ export function getCardAttachments(cardId: string): (state: RootState) => Attach
 
 export function getUploadPercent(blockId: string): (state: RootState) => number {
     return (state: RootState): number => {
-        return (state.attachments.attachments[blockId].uploadingPercent)
+        return state.attachments.attachments[blockId]?.uploadingPercent ?? 0
     }
 }


### PR DESCRIPTION
#### Summary
Deleting an attachment after a hard refresh would successfully call the API and show the success flash message, but then immediately redirect the user to the error page.

When an attachment is deleted, the server sends an update through WebSocket saying the attachment is deleted. The Redux store updates correctly and removes that attachment. At that exact moment, the AttachmentElement component is still on the screen. So when the selector runs again, it tries to find the attachment using the old blockId, but it’s already gone, and now it gets undefined. Then the code tries to access .uploadingPercent on that undefined value, which causes a crash. This is caught by `ErrorBoundary`, and redirects the user to `/error?id=unknown`. 

Fix: Added optional chaining fallback so the selector safely returns 0 when the block no longer exists in the store

Steps to Reproduce
- Open a board and open a card that has an attachment
- Hard refresh the page (Cmd+Shift+R / Ctrl+Shift+R)
- Open the card again and click the delete icon on the attachment
- Confirm the deletion

Before fix: redirected to the error page despite the API succeeding
After fix: attachment is deleted cleanly with the success flash message


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68059



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** Minimal. Changes are confined to a single Redux selector and a reducer guard in webapp/src/store/attachments.ts to defensively handle missing attachment entries (returns 0 instead of accessing undefined). No behavioral changes for valid states, no shared utilities or auth/data persistence touched, and blast radius is limited to attachment rendering flows.

**QA Recommendation:** Minimal manual QA. Validate the reported scenario (hard refresh, reopen card with attachment, delete attachment) to ensure deletion succeeds and no error-page redirect occurs. Automated rollback is straightforward.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->