### PR TITLE
MM-67913: stop managing app__body in MainApp

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -124,8 +124,10 @@ let browserHistory: History<unknown>
 
 const MainApp = (props: Props) => {
     useEffect(() => {
+        // Note: the host webapp owns the `app__body` class on `document.body` across product navigation.
+        // Adding/removing it here caused a persistent white flash when navigating Boards → Channels because
+        // this cleanup removed `app__body` before any other consumer could keep it applied (MM-67913).
         document.body.classList.add('focalboard-body')
-        document.body.classList.add('app__body')
         const root = document.getElementById('root')
         if (root) {
             root.classList.add('focalboard-plugin-root')
@@ -133,7 +135,6 @@ const MainApp = (props: Props) => {
 
         return () => {
             document.body.classList.remove('focalboard-body')
-            document.body.classList.remove('app__body')
             if (root) {
                 root.classList.remove('focalboard-plugin-root')
             }

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -125,8 +125,6 @@ let browserHistory: History<unknown>
 const MainApp = (props: Props) => {
     useEffect(() => {
         // Note: the host webapp owns the `app__body` class on `document.body` across product navigation.
-        // Adding/removing it here caused a persistent white flash when navigating Boards → Channels because
-        // this cleanup removed `app__body` before any other consumer could keep it applied (MM-67913).
         document.body.classList.add('focalboard-body')
         const root = document.getElementById('root')
         if (root) {


### PR DESCRIPTION
## Summary
Companion fix to [mattermost/mattermost#36186](https://github.com/mattermost/mattermost/pull/36186). Stops toggling `app__body` in `MainApp` — the host webapp now owns it. Plugin-scoped classes (`focalboard-body`, `focalboard-plugin-root`) are unchanged. See the main PR for root cause and runtime evidence.

## Ticket
[MM-67913](https://mattermost.atlassian.net/browse/MM-67913)

[MM-67913]: https://mattermost.atlassian.net/browse/MM-67913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Minimal. This change removes class-toggling responsibility from `MainApp` for a CSS class (`app__body`) that is now exclusively managed by the host webapp. The change is isolated to a single component's `useEffect` cleanup logic, affecting only DOM class manipulation without touching shared utilities, critical paths, or public APIs. The modification is actually a regression fix—the previous behavior was causing visual glitches (white flash on navigation) due to the class being prematurely removed. Removing this responsibility reduces complexity and eliminates a source of flashing.

**QA Recommendation:** Minimal manual QA required. Automated test coverage should verify that `MainApp` correctly initializes without throwing errors and that the `focalboard-body` and `focalboard-plugin-root` classes are still applied correctly. Manual verification should focus on confirming that the reported white flash no longer occurs when navigating between Boards and Channels, and that visual theming remains intact during plugin lifecycle transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->