### PR TITLE
[MM-63260] rerequest pull - Fixed comments select text under each card - issue #63

### DIFF
--- a/webapp/src/components/cardDetail/comment.scss
+++ b/webapp/src/components/cardDetail/comment.scss
@@ -67,5 +67,6 @@
 
     .comment-markdown > * {
         white-space: pre-wrap;
+        user-select: auto;
     }
 }

--- a/webapp/src/components/cardDetail/comment.scss
+++ b/webapp/src/components/cardDetail/comment.scss
@@ -67,6 +67,6 @@
 
     .comment-markdown > * {
         white-space: pre-wrap;
-        user-select: auto;
+        user-select: text;
     }
 }


### PR DESCRIPTION
See https://github.com/mattermost/mattermost-plugin-boards/pull/102#discussion_r2206826852

just added suggestion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Minimal regression risk. The change is a purely CSS-only modification adding `user-select: text;` to the `.comment-markdown > *` selector. This enables text selection for rendered markdown content in comments. No component logic, state management, or data flow is affected. The change does not introduce any untested code paths. Tests exist for the comment component, providing some coverage verification.

**QA Recommendation:** Minimal manual QA required. Verify that comment text and markdown content can be properly selected/highlighted by users. Confirm that copy-paste functionality works as expected. Visually inspect comments to ensure no unintended styling changes or rendering issues occur. Since this is an isolated CSS property addition affecting only user interaction with text, automated snapshot or visual regression tests would be sufficient if available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->