### PR TITLE
Bump minimum server version to 11.7.3

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-boards",
     "support_url": "https://github.com/mattermost/mattermost-plugin-boards/issues",
     "icon_path": "assets/starter-template-icon.svg",
-    "min_server_version": "10.7.0",
+    "min_server_version": "11.7.3",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -18,10 +18,10 @@ const manifestStr = `
   "description": "The Mattermost Boards plugin",
   "homepage_url": "https://github.com/mattermost/mattermost-plugin-boards",
   "support_url": "https://github.com/mattermost/mattermost-plugin-boards/issues",
-  "release_notes_url": "https://github.com/mattermost/mattermost-plugin-boards/releases",
+  "release_notes_url": "https://github.com/mattermost/mattermost-plugin-boards/releases/tag/v9.2.5",
   "icon_path": "assets/starter-template-icon.svg",
-  "version": "9.2.2",
-  "min_server_version": "10.7.0",
+  "version": "9.2.5",
+  "min_server_version": "11.7.3",
   "server": {
     "executables": {
       "darwin-amd64": "server/dist/plugin-darwin-amd64",

--- a/webapp/src/manifest.ts
+++ b/webapp/src/manifest.ts
@@ -15,7 +15,7 @@ const manifest = JSON.parse(`
     "support_url": "https://github.com/mattermost/mattermost-plugin-boards/issues",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-boards/releases/tag/v9.2.5",
     "icon_path": "assets/starter-template-icon.svg",
-    "version": "9.2.5",
+    "version": "0.0.0",
     "min_server_version": "11.7.3",
     "server": {
         "executables": {

--- a/webapp/src/manifest.ts
+++ b/webapp/src/manifest.ts
@@ -13,10 +13,10 @@ const manifest = JSON.parse(`
     "description": "The Mattermost Boards plugin",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-boards",
     "support_url": "https://github.com/mattermost/mattermost-plugin-boards/issues",
-    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-boards/releases/tag/v9.2.2",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-boards/releases/tag/v9.2.5",
     "icon_path": "assets/starter-template-icon.svg",
-    "version": "0.0.0",
-    "min_server_version": "10.7.0",
+    "version": "9.2.5",
+    "min_server_version": "11.7.3",
     "server": {
         "executables": {
             "darwin-amd64": "server/dist/plugin-darwin-amd64",


### PR DESCRIPTION
## Summary


This change: https://github.com/mattermost/mattermost-plugin-playbooks/pull/2237 made it into the 11.7 release when it was intended to wait until 11.8. To support ESR we've opted to rather than revert in Playbooks, have Agents, Boards, and Core fixes backported to 11.7 instead. This does mean we'll need to bump the min_server_version, otherwise weirdness can happen with CSS when switching Products.

- Updates `min_server_version` from `10.7.0` to `11.7.3` in `plugin.json`
- Regenerates `server/manifest.go` and `webapp/src/manifest.ts` via `make apply`

## Test plan

- [ ] Verify plugin loads on Mattermost 11.7.3+
- [ ] Confirm plugin reports the updated minimum server version in the system console


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** This is a metadata/manifest update raising `min_server_version` to 11.7.3 in plugin.json and regenerated manifests in server/manifest.go and webapp/src/manifest.ts. No functional code, shared utilities, authentication, data persistence, or public API changes are introduced. The only runtime effect is that installations on Mattermost versions older than 11.7.3 will be prevented from installing or will be flagged by the system console. Risk of regressions to existing behavior on supported servers (11.7.3+) is minimal.

**QA Recommendation:** Minimal manual QA. Run an automated deployment/load test to verify the plugin installs and loads on Mattermost 11.7.3+, and confirm the system console reports the updated minimum server version. Manual QA can be skipped if these checks pass.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->