### PR TITLE
Update minimum server version to 11.8.0

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-boards",
     "support_url": "https://github.com/mattermost/mattermost-plugin-boards/issues",
     "icon_path": "assets/starter-template-icon.svg",
-    "min_server_version": "10.7.0",
+    "min_server_version": "11.8.0",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -21,7 +21,7 @@ const manifestStr = `
   "release_notes_url": "https://github.com/mattermost/mattermost-plugin-boards/releases",
   "icon_path": "assets/starter-template-icon.svg",
   "version": "9.2.2",
-  "min_server_version": "10.7.0",
+  "min_server_version": "11.8.0",
   "server": {
     "executables": {
       "darwin-amd64": "server/dist/plugin-darwin-amd64",

--- a/webapp/src/manifest.ts
+++ b/webapp/src/manifest.ts
@@ -16,7 +16,7 @@ const manifest = JSON.parse(`
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-boards/releases/tag/v9.2.2",
     "icon_path": "assets/starter-template-icon.svg",
     "version": "0.0.0",
-    "min_server_version": "10.7.0",
+    "min_server_version": "11.8.0",
     "server": {
         "executables": {
             "darwin-amd64": "server/dist/plugin-darwin-amd64",


### PR DESCRIPTION
## Summary
- Updates the plugin `min_server_version` from `10.7.0` to `11.8.0`.
- Propagates the manifest change to generated server and webapp manifest copies.

## Test plan
- `make apply`
- `make check-style` (fails: Go lint cannot load config, `unsupported version of the configuration: ""`)
- `make test` (fails: webapp Jest passes, but `./build/sync` Go tests fail to compile against current local Go/toolchain APIs)


Made with [Cursor](https://cursor.com)