### PR TITLE
Use Mattermost 11.8 image for e2e tests

### DIFF
--- a/e2e/helpers/mmcontainer.ts
+++ b/e2e/helpers/mmcontainer.ts
@@ -17,7 +17,7 @@ const defaultUsername        = "admin";
 const defaultPassword        = "admin";
 const defaultTeamName        = "test";
 const defaultTeamDisplayName = "Test";
-const defaultMattermostImage = "mattermost/mattermost-enterprise-edition:11.5.1";
+const defaultMattermostImage = "mattermost/mattermost-enterprise-edition:release-11.8";
 
 type PluginConfig = Record<string, unknown>;
 type PluginConfigInput = PluginConfig | {config: PluginConfig};


### PR DESCRIPTION
## Summary
- Update the e2e Mattermost container default from the released 11.5.1 image to the `mattermost/mattermost-enterprise-edition:release-11.8` image so plugin installation matches the new minimum server version.

## Test plan
- Verified `docker manifest inspect mattermost/mattermost-enterprise-edition:release-11.8` succeeds.
