### PR TITLE
Fix Boards body class compatibility

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-boards",
     "support_url": "https://github.com/mattermost/mattermost-plugin-boards/issues",
     "icon_path": "assets/starter-template-icon.svg",
-    "min_server_version": "11.8.0",
+    "min_server_version": "10.7.0",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -21,7 +21,7 @@ const manifestStr = `
   "release_notes_url": "https://github.com/mattermost/mattermost-plugin-boards/releases",
   "icon_path": "assets/starter-template-icon.svg",
   "version": "9.2.2",
-  "min_server_version": "11.8.0",
+  "min_server_version": "10.7.0",
   "server": {
     "executables": {
       "darwin-amd64": "server/dist/plugin-darwin-amd64",

--- a/webapp/src/index.test.tsx
+++ b/webapp/src/index.test.tsx
@@ -1,0 +1,117 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react'
+import {render} from '@testing-library/react'
+import '@testing-library/jest-dom'
+
+import Plugin from './index'
+
+jest.mock('mattermost-redux/actions/teams', () => ({
+    selectTeam: jest.fn((teamId: string) => ({type: 'SELECT_TEAM', data: teamId})),
+}))
+jest.mock('./app', () => ({__esModule: true, default: () => null}))
+jest.mock('./components/withWebSockets', () => ({
+    __esModule: true,
+    default: (props: {children: React.ReactNode}) => props.children,
+}))
+jest.mock('./store', () => ({
+    __esModule: true,
+    default: {
+        getState: jest.fn(() => ({
+            teams: {
+                currentId: 'team-id',
+            },
+        })),
+        subscribe: jest.fn(() => jest.fn()),
+        dispatch: jest.fn(),
+    },
+}))
+jest.mock('./theme', () => ({
+    setMattermostTheme: jest.fn(),
+}))
+
+const fakeMattermostState = {
+    entities: {
+        general: {
+            config: {
+                SiteURL: '',
+            },
+        },
+        preferences: {
+            myPreferences: {
+                'display_settings--name_format': {value: 'username'},
+                theme: '{}',
+            },
+        },
+        channels: {
+            currentChannelId: 'channel-id',
+            channels: {
+                'channel-id': {id: 'channel-id'},
+            },
+        },
+        teams: {
+            currentTeamId: 'team-id',
+        },
+        users: {
+            currentUserId: 'user-id',
+        },
+    },
+}
+
+const fakeMattermostStore = {
+    getState: jest.fn(() => fakeMattermostState),
+    subscribe: jest.fn(() => jest.fn()),
+    dispatch: jest.fn(),
+}
+
+let CapturedMainApp: React.ComponentType<{webSocketClient: Record<string, never>}> | undefined
+
+const fakeRegistry = {
+    registerWebSocketEventHandler: jest.fn(),
+    registerPostTypeComponent: jest.fn(),
+    registerRightHandSidebarComponent: jest.fn(() => ({
+        rhsId: 'rhs-id',
+        toggleRHSPlugin: jest.fn(),
+    })),
+    registerChannelHeaderButtonAction: jest.fn(() => 'channel-header-button-id'),
+    registerProduct: jest.fn((...args: unknown[]) => {
+        CapturedMainApp = args[4] as React.ComponentType<{webSocketClient: Record<string, never>}>
+    }),
+    registerPostWillRenderEmbedComponent: jest.fn(),
+    registerRootComponent: jest.fn(() => 'root-component-id'),
+}
+
+beforeEach(() => {
+    document.body.className = ''
+    document.body.innerHTML = '<div id="root"></div>'
+    CapturedMainApp = undefined
+    jest.clearAllMocks()
+})
+
+test('keeps app body class sticky while cleaning up Boards classes', async () => {
+    const plugin = new Plugin()
+
+    await plugin.initialize(
+        fakeRegistry as unknown as Parameters<Plugin['initialize']>[0],
+        fakeMattermostStore as unknown as Parameters<Plugin['initialize']>[1],
+    )
+
+    expect(document.body).not.toHaveClass('app__body')
+    expect(document.body).not.toHaveClass('focalboard-body')
+    expect(document.getElementById('root')).not.toHaveClass('focalboard-plugin-root')
+
+    expect(CapturedMainApp).toBeDefined()
+    const MainApp = CapturedMainApp as React.ComponentType<{webSocketClient: Record<string, never>}>
+    const {unmount} = render(<MainApp webSocketClient={{}} />)
+
+    expect(document.body).toHaveClass('app__body')
+    expect(document.body).toHaveClass('focalboard-body')
+    expect(document.getElementById('root')).toHaveClass('focalboard-plugin-root')
+
+    unmount()
+
+    expect(document.body).toHaveClass('app__body')
+    expect(document.body).not.toHaveClass('focalboard-body')
+    expect(document.getElementById('root')).not.toHaveClass('focalboard-plugin-root')
+})

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -124,7 +124,8 @@ let browserHistory: History<unknown>
 
 const MainApp = (props: Props) => {
     useEffect(() => {
-        // Note: the host webapp owns the `app__body` class on `document.body` across product navigation.
+        // Mattermost 11.8+ owns `app__body`; Boards adds it for older hosts.
+        document.body.classList.add('app__body')
         document.body.classList.add('focalboard-body')
         const root = document.getElementById('root')
         if (root) {

--- a/webapp/src/manifest.ts
+++ b/webapp/src/manifest.ts
@@ -16,7 +16,7 @@ const manifest = JSON.parse(`
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-boards/releases/tag/v9.2.2",
     "icon_path": "assets/starter-template-icon.svg",
     "version": "0.0.0",
-    "min_server_version": "11.8.0",
+    "min_server_version": "10.7.0",
     "server": {
         "executables": {
             "darwin-amd64": "server/dist/plugin-darwin-amd64",


### PR DESCRIPTION
## Summary
- Add `app__body` when the Boards product mounts so older Mattermost hosts keep the expected body styling.
- Keep `app__body` sticky on unmount while preserving existing cleanup for `focalboard-body` and `focalboard-plugin-root`.
- Restore Boards manifest `min_server_version` values to `10.7.0`.

## Test plan
- `npm test -- --runInBand src/index.test.tsx --coverage=false`
- `npm run check-types`
- `npx eslint --ignore-pattern node_modules --ignore-pattern static --ignore-pattern dist --ext .js --ext .jsx --ext tsx --ext ts src/index.tsx src/index.test.tsx --quiet --cache`

## Release follow-up
- After merge, tag a new Boards release from main.
- Then bump the Mattermost plugin pin to the new Boards tag, accounting for FIPS artifact needs if required.


Made with [Cursor](https://cursor.com)