### PR TITLE
Add Persian language registration

### DIFF
--- a/webapp/src/i18n.tsx
+++ b/webapp/src/i18n.tsx
@@ -20,10 +20,11 @@ import messages_tr from '../i18n/tr.json'
 import messages_zhHans from '../i18n/zh_Hans.json'
 import messages_zhHant from '../i18n/zh_Hant.json'
 import messages_ko from '../i18n/ko.json'
+import messages_fa from '../i18n/fa.json'
 
 import {UserSettings} from './userSettings'
 
-const supportedLanguages = ['ca', 'de', 'el', 'en', 'es', 'fr', 'id', 'it', 'ja', 'nl', 'oc', 'pt-br', 'ru', 'sv', 'tr', 'zh-cn', 'zh-tw', 'ko']
+const supportedLanguages = ['ca', 'de', 'el', 'en', 'es', 'fr', 'id', 'it', 'ja', 'nl', 'oc', 'pt-br', 'ru', 'sv', 'tr', 'zh-cn', 'zh-tw', 'ko', 'fa']
 
 export function getMessages(lang: string): {[key: string]: string} {
     switch (lang) {
@@ -61,6 +62,8 @@ export function getMessages(lang: string): {[key: string]: string} {
         return messages_zhHant
     case 'ko':
         return messages_ko
+    case 'fa':
+        return messages_fa
     }
     return messages_en
 }


### PR DESCRIPTION
## Summary

Adds support for the existing Persian translation.

## Problem

The repository already contains `i18n/fa.json`, but Persian was not registered in the language configuration. As a result, it did not appear in the language selector.

## Solution

- Register `fa.json`
- Add Persian to the available language list

## Testing

- Verified Persian appears in the language selector
- Verified translations load correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Extremely low. The changes are purely additive and follow the exact established pattern for language registration used by all other languages (e.g., Korean). No existing code paths are modified—only a new import, array entry, and switch case are added. The Persian translation file (fa.json) already exists in the repository, so this simply registers it in the configuration. The default fallback to English remains unchanged.

**QA Recommendation:** Minimal manual QA required. Automated tests covering language selection and message retrieval should automatically validate the new Persian language option through pattern-based testing. Manual verification is limited to confirming Persian appears in the language selector UI and that translations load correctly when selected—both straightforward user-facing operations with negligible risk.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->