### PR TITLE
Fix missing Persian language option

### DIFF
--- a/webapp/src/constants.ts
+++ b/webapp/src/constants.ts
@@ -98,6 +98,11 @@ class Constants {
             displayName: '日本語',
         },
         {
+            code: 'fa',
+            name: 'farsi',
+            displayName: 'فارسی',
+        },
+        {
             code: 'fr',
             name: 'french',
             displayName: 'Français',

--- a/webapp/src/i18n.tsx
+++ b/webapp/src/i18n.tsx
@@ -7,6 +7,7 @@ import messages_de from '../i18n/de.json'
 import messages_el from '../i18n/el.json'
 import messages_en from '../i18n/en.json'
 import messages_es from '../i18n/es.json'
+import messages_fa from '../i18n/fa.json'
 import messages_fr from '../i18n/fr.json'
 import messages_id from '../i18n/id.json'
 import messages_it from '../i18n/it.json'
@@ -23,7 +24,7 @@ import messages_ko from '../i18n/ko.json'
 
 import {UserSettings} from './userSettings'
 
-const supportedLanguages = ['ca', 'de', 'el', 'en', 'es', 'fr', 'id', 'it', 'ja', 'nl', 'oc', 'pt-br', 'ru', 'sv', 'tr', 'zh-cn', 'zh-tw', 'ko']
+const supportedLanguages = ['ca', 'de', 'el', 'en', 'es', 'fa', 'fr', 'id', 'it', 'ja', 'nl', 'oc', 'pt-br', 'ru', 'sv', 'tr', 'zh-cn', 'zh-tw', 'ko']
 
 export function getMessages(lang: string): {[key: string]: string} {
     switch (lang) {
@@ -35,6 +36,8 @@ export function getMessages(lang: string): {[key: string]: string} {
         return messages_el
     case 'es':
         return messages_es
+    case 'fa':
+        return messages_fa
     case 'fr':
         return messages_fr
     case 'id':


### PR DESCRIPTION
## Summary

Adds support for the existing Persian translation.

## Problem

The repository already contains `i18n/fa.json`, but Persian was not registered in the language configuration. As a result, it did not appear in the language selector.

## Solution

- Register `fa.json`
- Add Persian to the available language list

## Testing

- Verified Persian appears in the language selector
- Verified translations load correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Minimal. This is a purely additive change that registers an existing Persian translation file (webapp/i18n/fa.json already exists). The changes follow the established pattern for language registration and do not modify any existing code paths. No shared utilities, base classes, or widely-imported modules are affected. The additions are confined to language configuration in constants.ts and i18n routing in i18n.tsx.

**QA Recommendation:** Minimal manual QA required. Given that this is a straightforward registration of an existing translation file following an established pattern with no behavioral changes to core functionality, automated testing coverage should be sufficient. Manual verification could focus on confirming that Persian (فارسی) appears in the language selector and that translations load correctly when selected, but this can be quick validation given the isolated nature of the change.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->