### PR TITLE
Fix missing Persian language option

### DIFF
--- a/webapp/src/constants.ts
+++ b/webapp/src/constants.ts
@@ -98,6 +98,11 @@ class Constants {
             displayName: '日本語',
         },
         {
+            code: 'fa',
+            name: 'farsi',
+            displayName: 'فارسی',
+        },
+        {
             code: 'fr',
             name: 'french',
             displayName: 'Français',

--- a/webapp/src/i18n.tsx
+++ b/webapp/src/i18n.tsx
@@ -7,6 +7,7 @@ import messages_de from '../i18n/de.json'
 import messages_el from '../i18n/el.json'
 import messages_en from '../i18n/en.json'
 import messages_es from '../i18n/es.json'
+import messages_fa from '../i18n/fa.json'
 import messages_fr from '../i18n/fr.json'
 import messages_id from '../i18n/id.json'
 import messages_it from '../i18n/it.json'
@@ -23,7 +24,7 @@ import messages_ko from '../i18n/ko.json'
 
 import {UserSettings} from './userSettings'
 
-const supportedLanguages = ['ca', 'de', 'el', 'en', 'es', 'fr', 'id', 'it', 'ja', 'nl', 'oc', 'pt-br', 'ru', 'sv', 'tr', 'zh-cn', 'zh-tw', 'ko']
+const supportedLanguages = ['ca', 'de', 'el', 'en', 'es', 'fr', 'fa', 'id', 'it', 'ja', 'nl', 'oc', 'pt-br', 'ru', 'sv', 'tr', 'zh-cn', 'zh-tw', 'ko']
 
 export function getMessages(lang: string): {[key: string]: string} {
     switch (lang) {
@@ -35,6 +36,8 @@ export function getMessages(lang: string): {[key: string]: string} {
         return messages_el
     case 'es':
         return messages_es
+    case 'fa':
+        return messages_fa
     case 'fr':
         return messages_fr
     case 'id':


### PR DESCRIPTION
## Summary

Adds support for the existing Persian translation.

## Problem

The repository already contains `i18n/fa.json`, but Persian was not registered in the language configuration. As a result, it did not appear in the language selector.

## Solution

- Register `fa.json`
- Add Persian to the available language list

## Testing

- Verified Persian appears in the language selector
- Verified translations load correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Minimal. This is a purely additive change that extends the existing language configuration without modifying any existing logic paths. The Persian (`fa`) language registration follows the established pattern already present in the codebase for other languages. No existing behavior is changed; the switch statement in `getMessages()` gains a new case, and the language array in constants expands. The translation file (`fa.json`) already exists with full Persian translations, indicating this addresses a pre-existing gap in configuration rather than introducing new untested code paths. The change touches only isolated UI elements (language selector) with no impact on core business logic or shared utilities.

**QA Recommendation:** Minimal manual QA required. Automated test coverage already exists for language selection functionality (globalHeaderSettingsMenu.test.tsx and sidebarSettingsMenu.test.tsx). A quick manual verification that Persian appears in the language dropdown menu and that translations load correctly would be sufficient. Focus should be on confirming the language selector displays Persian and that UI text properly renders in Persian locale.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->