### PR TITLE
Bump minimum server version to 11.9.0

### DIFF
--- a/e2e/helpers/mmcontainer.ts
+++ b/e2e/helpers/mmcontainer.ts
@@ -17,7 +17,7 @@ const defaultUsername        = "admin";
 const defaultPassword        = "admin";
 const defaultTeamName        = "test";
 const defaultTeamDisplayName = "Test";
-const defaultMattermostImage = "mattermost/mattermost-enterprise-edition:release-11.9";
+const defaultMattermostImage = "mattermostdevelopment/mattermost-enterprise-edition:release-11.9";
 
 type PluginConfig = Record<string, unknown>;
 type PluginConfigInput = PluginConfig | {config: PluginConfig};

--- a/e2e/helpers/mmcontainer.ts
+++ b/e2e/helpers/mmcontainer.ts
@@ -17,7 +17,7 @@ const defaultUsername        = "admin";
 const defaultPassword        = "admin";
 const defaultTeamName        = "test";
 const defaultTeamDisplayName = "Test";
-const defaultMattermostImage = "mattermost/mattermost-enterprise-edition:release-11.8";
+const defaultMattermostImage = "mattermost/mattermost-enterprise-edition:release-11.9";
 
 type PluginConfig = Record<string, unknown>;
 type PluginConfigInput = PluginConfig | {config: PluginConfig};

--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-boards",
     "support_url": "https://github.com/mattermost/mattermost-plugin-boards/issues",
     "icon_path": "assets/starter-template-icon.svg",
-    "min_server_version": "11.8.0",
+    "min_server_version": "11.9.0",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -21,7 +21,7 @@ const manifestStr = `
   "release_notes_url": "https://github.com/mattermost/mattermost-plugin-boards/releases",
   "icon_path": "assets/starter-template-icon.svg",
   "version": "9.2.2",
-  "min_server_version": "11.8.0",
+  "min_server_version": "11.9.0",
   "server": {
     "executables": {
       "darwin-amd64": "server/dist/plugin-darwin-amd64",

--- a/webapp/src/manifest.ts
+++ b/webapp/src/manifest.ts
@@ -16,7 +16,7 @@ const manifest = JSON.parse(`
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-boards/releases/tag/v9.2.2",
     "icon_path": "assets/starter-template-icon.svg",
     "version": "0.0.0",
-    "min_server_version": "11.8.0",
+    "min_server_version": "11.9.0",
     "server": {
         "executables": {
             "darwin-amd64": "server/dist/plugin-darwin-amd64",


### PR DESCRIPTION
## Summary

WIP/draft PR for bumping the Boards minimum Mattermost server version to 11.9.0 and defaulting the local e2e Mattermost image to `mattermost/mattermost-enterprise-edition:release-11.9`.

This should stay draft until the `release-11.9` branch and `mattermost/mattermost-enterprise-edition:release-11.9` image exist so final validation can run against the real target image.

## Validation

Already passed/recorded:
- `make apply`
- `make dist-linux`
- Temporary-image E2E validation had one transient full-suite failure; targeted rerun passed.

Known local gaps to confirm via CI or a compatible local environment:
- `make check-style` currently hits a local golangci-lint config loading issue.
- `make test` currently hits an unrelated `build/sync` compilation issue.

Final follow-up before marking ready:
- Rerun full `make e2e-ci` without `MM_IMAGE` against the real `release-11.9` image.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Extremely low. The changes are isolated configuration and version constraint updates with no code logic modifications. The alterations touch only version declarations in `plugin.json`, auto-generated manifest files, and test infrastructure (Docker image tag). No shared utilities, base classes, or widely-imported modules are affected. No side effects can propagate to unrelated system areas since this is purely a version gating mechanism.

**QA Recommendation:** Minimal manual QA required. Automated test coverage via CI (particularly `make e2e-ci` against the release-11.9 image as noted in the PR objectives) is the primary validation mechanism. Functional verification should focus on: (1) confirming the plugin fails to load on Mattermost 11.8.x with an appropriate version mismatch error, and (2) verifying normal plugin behavior on Mattermost 11.9.0+. The e2e test infrastructure changes do not introduce behavioral regressions—they align the test environment with the declared minimum version requirement.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->