### PR TITLE
MM-69032: gate channelId mutations behind PermissionManageBoardRoles …

### DIFF
--- a/server/api/boards.go
+++ b/server/api/boards.go
@@ -26,6 +26,26 @@ func (a *API) registerBoardsRoutes(r *mux.Router) {
 	r.HandleFunc("/boards/{boardID}/metadata", a.sessionRequired(a.handleGetBoardMetadata)).Methods("GET")
 }
 
+func (a *API) authorizeBoardPatch(userID, boardID string, patch *model.BoardPatch) error {
+	if !a.permissions.HasPermissionToBoard(userID, boardID, model.PermissionManageBoardProperties) {
+		return model.NewErrPermission("access denied to modifying board properties")
+	}
+
+	if patch.Type != nil || patch.MinimumRole != nil {
+		if !a.permissions.HasPermissionToBoard(userID, boardID, model.PermissionManageBoardType) {
+			return model.NewErrPermission("access denied to modifying board type")
+		}
+	}
+
+	if patch.ChannelID != nil {
+		if !a.permissions.HasPermissionToBoard(userID, boardID, model.PermissionManageBoardRoles) {
+			return model.NewErrPermission("access denied to modifying board access")
+		}
+	}
+
+	return nil
+}
+
 func (a *API) handleGetBoards(w http.ResponseWriter, r *http.Request) {
 	// swagger:operation GET /teams/{teamID}/boards getBoards
 	//
@@ -353,22 +373,9 @@ func (a *API) handlePatchBoard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !a.permissions.HasPermissionToBoard(userID, boardID, model.PermissionManageBoardProperties) {
-		a.errorResponse(w, r, model.NewErrPermission("access denied to modifying board properties"))
+	if err = a.authorizeBoardPatch(userID, boardID, patch); err != nil {
+		a.errorResponse(w, r, err)
 		return
-	}
-
-	if patch.Type != nil || patch.MinimumRole != nil {
-		if !a.permissions.HasPermissionToBoard(userID, boardID, model.PermissionManageBoardType) {
-			a.errorResponse(w, r, model.NewErrPermission("access denied to modifying board type"))
-			return
-		}
-	}
-	if patch.ChannelID != nil {
-		if !a.permissions.HasPermissionToBoard(userID, boardID, model.PermissionManageBoardRoles) {
-			a.errorResponse(w, r, model.NewErrPermission("access denied to modifying board access"))
-			return
-		}
 	}
 
 	auditRec := a.makeAuditRecord(r, "patchBoard", audit.Fail)

--- a/server/api/boards_and_blocks.go
+++ b/server/api/boards_and_blocks.go
@@ -235,16 +235,9 @@ func (a *API) handlePatchBoardsAndBlocks(w http.ResponseWriter, r *http.Request)
 			return
 		}
 
-		if !a.permissions.HasPermissionToBoard(userID, boardID, model.PermissionManageBoardProperties) {
-			a.errorResponse(w, r, model.NewErrPermission("access denied to modifying board properties"))
+		if err = a.authorizeBoardPatch(userID, boardID, patch); err != nil {
+			a.errorResponse(w, r, err)
 			return
-		}
-
-		if patch.Type != nil || patch.MinimumRole != nil {
-			if !a.permissions.HasPermissionToBoard(userID, boardID, model.PermissionManageBoardType) {
-				a.errorResponse(w, r, model.NewErrPermission("access denied to modifying board type"))
-				return
-			}
 		}
 
 		board, err2 := a.app.GetBoard(boardID)

--- a/server/app/boards.go
+++ b/server/app/boards.go
@@ -56,6 +56,12 @@ func (a *App) validateBoardChannelPatchAccess(userID string, board *model.Board,
 		return nil
 	}
 
+	if patch.ChannelID != nil {
+		if !a.permissions.HasPermissionToBoard(userID, board.ID, model.PermissionManageBoardRoles) {
+			return model.NewErrPermission("access denied to modifying board access")
+		}
+	}
+
 	testChannel := ""
 	if patch.ChannelID != nil && *patch.ChannelID != "" {
 		testChannel = *patch.ChannelID

--- a/server/app/boards_test.go
+++ b/server/app/boards_test.go
@@ -484,6 +484,7 @@ func TestPatchBoard(t *testing.T) {
 			IsTemplate: true,
 		}, nil).Times(1)
 
+		th.expectBoardAdmin(userID, boardID, teamID)
 		th.API.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(false).Times(1)
 		_, err := th.App.PatchBoard(patch, boardID, userID)
 		require.Error(t, err)
@@ -507,6 +508,7 @@ func TestPatchBoard(t *testing.T) {
 			IsTemplate: true,
 		}, nil).Times(1)
 
+		th.expectBoardAdmin(userID, boardID, teamID)
 		th.API.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(true).Times(1)
 		th.API.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionCreatePost).Return(false).Times(1)
 		_, err := th.App.PatchBoard(patch, boardID, userID)
@@ -530,6 +532,7 @@ func TestPatchBoard(t *testing.T) {
 			TeamID: teamID,
 		}, nil).Times(2)
 
+		th.expectBoardAdmin(userID, boardID, teamID)
 		th.API.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(true).Times(1)
 		th.API.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionCreatePost).Return(true).Times(1)
 
@@ -574,6 +577,7 @@ func TestPatchBoard(t *testing.T) {
 			ChannelID:  channelID,
 		}, nil).Times(2)
 
+		th.expectBoardAdmin(userID, boardID, teamID)
 		th.API.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(false).Times(1)
 
 		th.API.EXPECT().HasPermissionToTeam(userID, teamID, model.PermissionManageTeam).Return(false).Times(1)
@@ -742,6 +746,7 @@ func TestPatchBoardsAndBlocksChannelAccess(t *testing.T) {
 			TeamID: teamID,
 		}, nil).Times(1)
 
+		th.expectBoardAdmin(userID, boardID, teamID)
 		th.API.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(false).Times(1)
 
 		_, err := th.App.PatchBoardsAndBlocks(pbab, userID)
@@ -770,6 +775,7 @@ func TestPatchBoardsAndBlocksChannelAccess(t *testing.T) {
 			TeamID: teamID,
 		}, nil).Times(1)
 
+		th.expectBoardAdmin(userID, boardID, teamID)
 		th.API.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(true).Times(1)
 		th.API.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionCreatePost).Return(false).Times(1)
 
@@ -806,6 +812,7 @@ func TestPatchBoardsAndBlocksChannelAccess(t *testing.T) {
 			TeamID: teamID,
 		}, nil).Times(1)
 
+		th.expectBoardAdmin(userID, boardID, teamID)
 		th.API.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(true).Times(1)
 		th.API.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionCreatePost).Return(true).Times(1)
 
@@ -815,6 +822,34 @@ func TestPatchBoardsAndBlocksChannelAccess(t *testing.T) {
 		patchedBab, err := th.App.PatchBoardsAndBlocks(pbab, userID)
 		require.NoError(t, err)
 		require.Equal(t, channelID, patchedBab.Boards[0].ChannelID)
+	})
+
+	t.Run("patch channel by board editor is rejected", func(t *testing.T) {
+		const boardID = "board_id_1"
+		const userID = "user_id_1"
+		const teamID = "team_id_1"
+		channelID := "any_channel"
+
+		patch := &model.BoardPatch{
+			ChannelID: &channelID,
+		}
+		pbab := &model.PatchBoardsAndBlocks{
+			BoardIDs:     []string{boardID},
+			BoardPatches: []*model.BoardPatch{patch},
+		}
+
+		expectPatchBoardsAndBlocksSetup()
+
+		th.Store.EXPECT().GetBoard(boardID).Return(&model.Board{
+			ID:     boardID,
+			TeamID: teamID,
+		}, nil).Times(1)
+
+		th.expectBoardEditor(userID, boardID, teamID)
+
+		_, err := th.App.PatchBoardsAndBlocks(pbab, userID)
+		require.Error(t, err)
+		require.True(t, model.IsErrForbidden(err))
 	})
 }
 

--- a/server/app/helper_test.go
+++ b/server/app/helper_test.go
@@ -75,7 +75,7 @@ func SetupTestHelper(t *testing.T) (*TestHelper, func()) {
 	}, tearDown
 }
 
-func (th *TestHelper) expectBoardAdmin(userID, boardID, teamID string) {
+func (th *TestHelper) expectBoardAdmin(userID, boardID, teamID string) { //nolint:unparam
 	th.PermStore.EXPECT().GetBoard(boardID).Return(&model.Board{
 		ID:     boardID,
 		TeamID: teamID,

--- a/server/app/helper_test.go
+++ b/server/app/helper_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang/mock/gomock"
 
 	"github.com/mattermost/mattermost-plugin-boards/server/auth"
+	"github.com/mattermost/mattermost-plugin-boards/server/model"
 	"github.com/mattermost/mattermost-plugin-boards/server/services/config"
 	"github.com/mattermost/mattermost-plugin-boards/server/services/metrics"
 	"github.com/mattermost/mattermost-plugin-boards/server/services/permissions/mmpermissions"
@@ -27,6 +28,7 @@ type TestHelper struct {
 	FilesBackend *mocks.FileBackend
 	logger       mlog.LoggerIFace
 	API          *mmpermissionsMocks.MockAPI
+	PermStore    *permissionsMocks.MockStore
 }
 
 func SetupTestHelper(t *testing.T) (*TestHelper, func()) {
@@ -69,5 +71,33 @@ func SetupTestHelper(t *testing.T) (*TestHelper, func()) {
 		FilesBackend: filesBackend,
 		logger:       logger,
 		API:          mockAPI,
+		PermStore:    mockStore,
 	}, tearDown
+}
+
+func (th *TestHelper) expectBoardAdmin(userID, boardID, teamID string) {
+	th.PermStore.EXPECT().GetBoard(boardID).Return(&model.Board{
+		ID:     boardID,
+		TeamID: teamID,
+	}, nil)
+	th.API.EXPECT().HasPermissionToTeam(userID, teamID, model.PermissionViewTeam).Return(true)
+	th.PermStore.EXPECT().GetMemberForBoard(boardID, userID).Return(&model.BoardMember{
+		BoardID:     boardID,
+		UserID:      userID,
+		SchemeAdmin: true,
+	}, nil)
+}
+
+func (th *TestHelper) expectBoardEditor(userID, boardID, teamID string) {
+	th.PermStore.EXPECT().GetBoard(boardID).Return(&model.Board{
+		ID:     boardID,
+		TeamID: teamID,
+	}, nil)
+	th.API.EXPECT().HasPermissionToTeam(userID, teamID, model.PermissionViewTeam).Return(true)
+	th.PermStore.EXPECT().GetMemberForBoard(boardID, userID).Return(&model.BoardMember{
+		BoardID:      boardID,
+		UserID:       userID,
+		SchemeEditor: true,
+	}, nil)
+	th.API.EXPECT().HasPermissionToTeam(userID, teamID, model.PermissionManageTeam).Return(false)
 }

--- a/server/integrationtests/permissions_test.go
+++ b/server/integrationtests/permissions_test.go
@@ -2275,6 +2275,37 @@ func TestPermissionsUpdateBoardsAndBlocks(t *testing.T) {
 	runTestCases(t, ttCases, testData, clients, testTeamID, otherTeamID, emptyTeamID)
 }
 
+func TestPermissionsPatchBoardsAndBlocksChannelId(t *testing.T) {
+	ttCasesF := func(t *testing.T, testData TestData) []TestCase {
+		validChannelID := mmModel.NewId()
+		bab := toJSON(t, model.PatchBoardsAndBlocks{
+			BoardIDs:     []string{testData.publicBoard.ID},
+			BoardPatches: []*model.BoardPatch{{ChannelID: &validChannelID}},
+			BlockIDs:     []string{},
+			BlockPatches: []*model.BlockPatch{},
+		})
+
+		return []TestCase{
+			{"/boards-and-blocks", methodPatch, bab, userAnon, http.StatusUnauthorized, 0},
+			{"/boards-and-blocks", methodPatch, bab, userNoTeamMember, http.StatusForbidden, 0},
+			{"/boards-and-blocks", methodPatch, bab, userTeamMember, http.StatusForbidden, 0},
+			{"/boards-and-blocks", methodPatch, bab, userViewer, http.StatusForbidden, 0},
+			{"/boards-and-blocks", methodPatch, bab, userCommenter, http.StatusForbidden, 0},
+			{"/boards-and-blocks", methodPatch, bab, userEditor, http.StatusForbidden, 0},
+			{"/boards-and-blocks", methodPatch, bab, userGuest, http.StatusForbidden, 0},
+			{"/boards-and-blocks", methodPatch, bab, userAdmin, http.StatusOK, 1},
+		}
+	}
+
+	th := SetupTestHelperPluginMode(t)
+	defer th.TearDown()
+	clients := setupClients(th)
+	testData := setupData(t, th)
+	ttCases := ttCasesF(t, testData)
+	testTeamID, otherTeamID, emptyTeamID := th.GetTestTeamIDs()
+	runTestCases(t, ttCases, testData, clients, testTeamID, otherTeamID, emptyTeamID)
+}
+
 func TestPermissionsDeleteBoardsAndBlocks(t *testing.T) {
 	ttCasesF := func(t *testing.T, testData TestData) []TestCase {
 		bab := toJSON(t, model.DeleteBoardsAndBlocks{


### PR DESCRIPTION

#### Summary
Closes the privilege escalation:`PATCH /boards-and-blocks` let any board editor relink a board to an arbitrary channel.
The single-board `PATCH /boards/{boardID}` already enforced `PermissionManageBoardRoles` for `channelId` mutations, but the batch endpoint did not.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69032

#### QA
The vulnerable path was the batch endpoint which only client code that batches block and board patches together can hit. To verify run these against a fresh build.

Prereqs: system admin `admin_user`, regular member `editor_user` on the same team. Replace `$HOST`, `$TEAM_ID`, `$EDITOR_USER_ID`, `$TARGET_CHANNEL_ID` and the two tokens.

```bash
# admin creates a board and makes editor_user a board editor
BOARD_ID=$(curl -sS -X POST "$HOST/plugins/focalboard/api/v2/boards" \
  -H "Authorization: Bearer $ADMIN_TOKEN" -H 'X-Requested-With: XMLHttpRequest' \
  -H 'Content-Type: application/json' \
  -d "{\"teamId\":\"$TEAM_ID\",\"title\":\"probe\",\"type\":\"O\",\"minimumRole\":\"editor\"}" \
  | jq -r '.id')

curl -sS -X POST "$HOST/plugins/focalboard/api/v2/boards/$BOARD_ID/members" \
  -H "Authorization: Bearer $ADMIN_TOKEN" -H 'X-Requested-With: XMLHttpRequest' \
  -H 'Content-Type: application/json' \
  -d "{\"boardId\":\"$BOARD_ID\",\"userId\":\"$EDITOR_USER_ID\",\"schemeEditor\":true}" >/dev/null

# editor attempts the exploit -> must be rejected
curl -i -sS -X PATCH "$HOST/plugins/focalboard/api/v2/boards-and-blocks" \
  -H "Authorization: Bearer $EDITOR_TOKEN" -H 'X-Requested-With: XMLHttpRequest' \
  -H 'Content-Type: application/json' \
  -d "{\"boardIDs\":[\"$BOARD_ID\"],\"boardPatches\":[{\"channelId\":\"$TARGET_CHANNEL_ID\"}],\"blockIDs\":[],\"blockPatches\":[]}"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟠 Medium

**Regression Risk:** Medium. The change updates authorization for `channelId` mutations on the batch endpoint (`PATCH /boards-and-blocks`) by adding `PermissionManageBoardRoles` enforcement. This intentionally alters outcomes for previously-permitted (but unauthorized) editor attempts, with risk confined to requests that include `ChannelID` updates; other patch fields should be unaffected.  
**QA Recommendation:** Light manual QA recommended—smoke test a `channelId` relink attempt via `PATCH /boards-and-blocks` for both an unauthorized board editor and an admin, plus a mixed batch payload that includes board/block patches.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->