### PR TITLE
Add FIPS build support for Linux/amd64 plugin releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,9 @@ jobs:
     # Skip FIPS testing for forks, which won't have the chainguard identity.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-22.04
+    needs:
+      - server-test
+      - webapp-test
     permissions:
       contents: read
       id-token: write
@@ -99,6 +102,9 @@ jobs:
           node-version-file: .nvmrc
       - name: npm ci
         run: cd webapp && npm ci
+      - name: Get short SHA
+        id: short-sha
+        run: echo "sha=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
       - name: Build FIPS
         uses: mattermost/actions/plugin-ci/build-fips@c7a06bc642f72fc227deb2cae3af03cff72c0f0d
         with:
@@ -106,7 +112,7 @@ jobs:
       - name: Upload FIPS build artifact
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
-          name: boards-bundle-fips
+          name: boards-bundle-fips-${{ steps.short-sha.outputs.sha }}
           path: dist-fips/boards-*.tar.gz
           retention-days: 7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,39 @@ jobs:
       dist-target: "dist-linux"
       s3-prefix: "mattermost-plugin-boards"
 
+  dist-fips:
+    # Skip FIPS testing for forks, which won't have the chainguard identity.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        with:
+          go-version-file: go.mod
+      - name: Setup Node
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version-file: .nvmrc
+      - name: npm ci
+        run: cd webapp && npm ci
+      - name: Build FIPS
+        uses: mattermost/actions/plugin-ci/build-fips@c7a06bc642f72fc227deb2cae3af03cff72c0f0d
+        with:
+          chainguard-identity: ${{ secrets.CHAINGUARD_IDENTITY }}
+      - name: Upload FIPS build artifact
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: boards-bundle-fips
+          path: dist-fips/boards-*.tar.gz
+          retention-days: 7
+
   e2e:
     runs-on: ubuntu-22.04
     timeout-minutes: 60

--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,17 @@ default: all
 include build/setup.mk
 
 BUNDLE_NAME ?= $(PLUGIN_NAME)-$(PLUGIN_VERSION).tar.gz
+BUNDLE_DIR ?= dist
+SERVER_DIST_SRC ?= server/dist
 
 # Include custom makefile, if present
 ifneq ($(wildcard build/custom.mk),)
 	include build/custom.mk
+endif
+
+# Presence of build/fips.mk is the per-plugin FIPS opt-in marker.
+ifneq ($(wildcard build/fips.mk),)
+	include build/fips.mk
 endif
 
 ## Checks the code style, tests, builds and bundles the plugin.
@@ -150,33 +157,33 @@ endif
 ## Generates a tar bundle of the plugin for install.
 .PHONY: bundle
 bundle:
-	rm -rf dist/
-	mkdir -p dist/$(PLUGIN_NAME)
-	cp $(MANIFEST_FILE) dist/$(PLUGIN_NAME)/
-	cp -r webapp/pack dist/$(PLUGIN_NAME)/
+	rm -rf $(BUNDLE_DIR)/
+	mkdir -p $(BUNDLE_DIR)/$(PLUGIN_NAME)
+	cp $(MANIFEST_FILE) $(BUNDLE_DIR)/$(PLUGIN_NAME)/
+	cp -r webapp/pack $(BUNDLE_DIR)/$(PLUGIN_NAME)/
 ifneq ($(wildcard LICENSE.txt),)
-	cp -r LICENSE.txt dist/$(PLUGIN_NAME)/
+	cp -r LICENSE.txt $(BUNDLE_DIR)/$(PLUGIN_NAME)/
 endif
 ifneq ($(wildcard NOTICE.txt),)
-	cp -r NOTICE.txt dist/$(PLUGIN_NAME)/
+	cp -r NOTICE.txt $(BUNDLE_DIR)/$(PLUGIN_NAME)/
 endif
 ifneq ($(wildcard $(ASSETS_DIR)/.),)
-	cp -r $(ASSETS_DIR) dist/$(PLUGIN_NAME)/
+	cp -r $(ASSETS_DIR) $(BUNDLE_DIR)/$(PLUGIN_NAME)/
 endif
 ifneq ($(HAS_PUBLIC),)
-	cp -r public dist/$(PLUGIN_NAME)/public/
+	cp -r public $(BUNDLE_DIR)/$(PLUGIN_NAME)/public/
 endif
 ifneq ($(HAS_SERVER),)
-	mkdir -p dist/$(PLUGIN_NAME)/server
-	cp -r server/dist dist/$(PLUGIN_NAME)/server/
+	mkdir -p $(BUNDLE_DIR)/$(PLUGIN_NAME)/server/dist
+	cp -r $(SERVER_DIST_SRC)/. $(BUNDLE_DIR)/$(PLUGIN_NAME)/server/dist/
 endif
 ifneq ($(HAS_WEBAPP),)
-	mkdir -p dist/$(PLUGIN_NAME)/webapp
-	cp -r webapp/dist dist/$(PLUGIN_NAME)/webapp/
+	mkdir -p $(BUNDLE_DIR)/$(PLUGIN_NAME)/webapp
+	cp -r webapp/dist $(BUNDLE_DIR)/$(PLUGIN_NAME)/webapp/
 endif
-	cd dist && tar -cvzf $(BUNDLE_NAME) $(PLUGIN_NAME)
+	cd $(BUNDLE_DIR) && tar -cvzf $(BUNDLE_NAME) $(PLUGIN_NAME)
 
-	@echo plugin built at: dist/$(BUNDLE_NAME)
+	@echo plugin built at: $(BUNDLE_DIR)/$(BUNDLE_NAME)
 
 info: ## Display build information
 	@echo "Build Number: $(BUILD_NUMBER)"
@@ -340,10 +347,13 @@ kill: detach
 clean:
 	rm -rf bin
 	rm -rf dist
+	rm -rf dist-fips
 	rm -rf webapp/pack
 ifneq ($(HAS_SERVER),)
 	rm -fr server/coverage.txt
 	rm -fr server/dist
+	rm -fr server/dist-fips
+	rm -fr server/dist-fips-staged
 endif
 ifneq ($(HAS_WEBAPP),)
 	rm -fr webapp/junit.xml

--- a/build/fips.mk
+++ b/build/fips.mk
@@ -17,6 +17,9 @@ FIPS_GO_BUILD_LDFLAGS ?=
 # GO_BUILD_* are Make-substituted into the single-quoted inner script.
 # Env-var passing (`-e VAR=...`) doesn't survive a second pass of word
 # splitting on values with embedded quotes like `-gcflags "all=-N -l"`.
+# Boards sets GO_BUILD_FLAGS with single-quoted -ldflags, which breaks the
+# single-quoted docker inner script and drops -o (go then tries to write "server").
+# Pass build metadata via env vars and use double-quoted -ldflags instead.
 .PHONY: server-fips
 server-fips: templates-archive
 	mkdir -p server/dist-fips
@@ -24,10 +27,14 @@ server-fips: templates-archive
 	  --entrypoint="" \
 	  -v $(PWD):/plugin \
 	  -w /plugin/server \
+	  -e BUILD_NUMBER=$(BUILD_NUMBER) \
+	  -e BUILD_DATE="$(BUILD_DATE)" \
+	  -e BUILD_HASH=$(BUILD_HASH) \
 	  $(FIPS_IMAGE) \
 	  /bin/sh -c 'CGO_ENABLED=1 GOOS=linux GOARCH=amd64 \
 	    go build -trimpath -buildvcs=false \
-	    $(GO_BUILD_FLAGS) $(GO_BUILD_GCFLAGS) $(FIPS_GO_BUILD_LDFLAGS) \
+	    -ldflags "-X github.com/mattermost/focalboard/server/model.BuildNumber=$${BUILD_NUMBER} -X github.com/mattermost/focalboard/server/model.BuildDate=$${BUILD_DATE} -X github.com/mattermost/focalboard/server/model.BuildHash=$${BUILD_HASH} -X github.com/mattermost/focalboard/server/model.Edition=plugin" \
+	    $(GO_BUILD_GCFLAGS) $(FIPS_GO_BUILD_LDFLAGS) \
 	    -tags requirefips \
 	    -o dist-fips/plugin-linux-amd64-fips'
 

--- a/build/fips.mk
+++ b/build/fips.mk
@@ -1,0 +1,60 @@
+# FIPS-compliant Linux/amd64 build. Linux/amd64 is the only platform
+# mattermost-server's FIPS release path supports.
+
+FIPS_IMAGE ?= cgr.dev/mattermost.com/go-msft-fips:1.26.3-dev@sha256:48ab99fede7fb33e132a0636072971e1ec4a69520865bfa1e4b517ee9cfdef34
+# Same filename as the non-FIPS bundle on purpose: `make upload-to-server`
+# (called from .github/actions/e2e-test) expects `dist/$(BUNDLE_NAME)`. The
+# FIPS variant lives in dist-fips/, so there's no collision. delivery-platform's
+# release pipeline renames to `<plugin>-<version>+<sha>-fips.tar.gz` itself.
+BUNDLE_NAME_FIPS ?= $(BUNDLE_NAME)
+FIPS_BIN := server/dist-fips/plugin-linux-amd64-fips
+
+# Empty by default. Inheriting the plugin's release LDFLAGS (`-ldflags="-s -w"`)
+# would strip the symbol table, and verify-fips below needs symbols intact
+# for `go tool nm` to find the OpenSSL integration.
+FIPS_GO_BUILD_LDFLAGS ?=
+
+# GO_BUILD_* are Make-substituted into the single-quoted inner script.
+# Env-var passing (`-e VAR=...`) doesn't survive a second pass of word
+# splitting on values with embedded quotes like `-gcflags "all=-N -l"`.
+.PHONY: server-fips
+server-fips: templates-archive
+	mkdir -p server/dist-fips
+	docker run --rm \
+	  --entrypoint="" \
+	  -v $(PWD):/plugin \
+	  -w /plugin/server \
+	  $(FIPS_IMAGE) \
+	  /bin/sh -c 'CGO_ENABLED=1 GOOS=linux GOARCH=amd64 \
+	    go build -trimpath -buildvcs=false \
+	    $(GO_BUILD_FLAGS) $(GO_BUILD_GCFLAGS) $(FIPS_GO_BUILD_LDFLAGS) \
+	    -tags requirefips \
+	    -o dist-fips/plugin-linux-amd64-fips'
+
+# Mirrors mattermost-server/build/release.mk. Each check is its own recipe
+# line so a failure exits with the right status; joined with `; \`, only
+# the last command's exit propagates and a failed check would be masked.
+.PHONY: verify-fips
+verify-fips:
+	@test -f $(FIPS_BIN) || (echo "verify-fips: $(FIPS_BIN) not built" && exit 1)
+	$(GO) version -m $(FIPS_BIN) | grep -q "GOEXPERIMENT=systemcrypto" || (echo "ERROR: missing GOEXPERIMENT=systemcrypto" && exit 1)
+	$(GO) version -m $(FIPS_BIN) | grep "\-tags" | grep -q "requirefips" || (echo "ERROR: missing -tags=requirefips" && exit 1)
+	$(GO) tool nm $(FIPS_BIN) | grep -qE "func_go_openssl_OpenSSL_version|_mkcgo_OpenSSL_version" || (echo "ERROR: missing OpenSSL integration" && exit 1)
+	@echo "verify-fips: OK"
+
+# Depends on verify-fips so a direct `make bundle-fips` can't package an
+# unverified binary. Phony-target dedup means dist-fips / dist-all still
+# run verify-fips exactly once.
+.PHONY: bundle-fips
+bundle-fips: verify-fips
+	rm -rf server/dist-fips-staged
+	mkdir -p server/dist-fips-staged
+	cp $(FIPS_BIN) server/dist-fips-staged/plugin-linux-amd64
+	$(MAKE) bundle BUNDLE_DIR=dist-fips BUNDLE_NAME=$(BUNDLE_NAME_FIPS) SERVER_DIST_SRC=server/dist-fips-staged
+
+.PHONY: dist-fips
+dist-fips: apply server-fips verify-fips webapp bundle-fips
+
+# Flat prerequisite list so `apply` and `webapp` run once, not twice.
+.PHONY: dist-all
+dist-all: apply webapp server server-fips verify-fips bundle bundle-fips


### PR DESCRIPTION
## Summary

- Add `build/fips.mk` with Chainguard-based FIPS linux/amd64 build, verification, and bundling targets (mirrors mattermost-plugin-playbooks#2281).
- Parameterize the Makefile `bundle` target so FIPS artifacts land in `dist-fips/` without changing the standard build output.
- Add a `dist-fips` CI job using `mattermost/actions/plugin-ci/build-fips` to build and upload FIPS bundles on PRs.

## Test plan

- [x] Confirm `dist-fips` CI job passes (requires `CHAINGUARD_IDENTITY` repo secret)
- [x] Download `boards-bundle-fips` artifact and verify tarball contains `server/dist/plugin-linux-amd64`
- [x] Confirm existing `dist` and `e2e` jobs are unaffected


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟠 Medium

**Regression Risk:** The Makefile refactor touches the shared packaging/bundling pipeline (tarball layout, staging locations, and clean-up), so mistakes in the new parameterized paths could subtly change the contents of existing `dist` artifacts even with default values. FIPS build additions are additive, but `dist-all`/conditional `build/fips.mk` inclusion could affect CI flows that use those targets.

**QA Recommendation:** Rely primarily on CI: verify existing `dist` and `e2e` jobs remain unchanged and pass, and ensure the new `dist-fips` job succeeds when `CHAINGUARD_IDENTITY` is set. For extra confidence, download and inspect the `boards-bundle-fips` artifact to confirm it contains the expected `server/dist/plugin-linux-amd64` FIPS binary path/content; then run one quick bundle-extraction smoke check for both `dist/` and `dist-fips/` tarballs to confirm file layout and names.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->