### PR TITLE
MM-69048: Validate WebSocket command field types to prevent plugin crash 

### DIFF
--- a/server/ws/plugin_adapter.go
+++ b/server/ws/plugin_adapter.go
@@ -21,7 +21,14 @@ import (
 
 const websocketMessagePrefix = "custom_focalboard_"
 
-var errMissingTeamInCommand = fmt.Errorf("command doesn't contain teamId")
+var (
+	errMissingTeamInCommand = fmt.Errorf("command doesn't contain teamId")
+	errInvalidFieldType     = fmt.Errorf("invalid field type in websocket command")
+)
+
+func invalidFieldTypeError(field string, value interface{}) error {
+	return fmt.Errorf("%w: %q has type %T", errInvalidFieldType, field, value)
+}
 
 type PluginAdapterInterface interface {
 	Adapter
@@ -311,24 +318,55 @@ func (pa *PluginAdapter) OnWebSocketDisconnect(webConnID, userID string) {
 func commandFromRequest(req *mmModel.WebSocketRequest) (*WebsocketCommand, error) {
 	c := &WebsocketCommand{Action: strings.TrimPrefix(req.Action, websocketMessagePrefix)}
 
-	if teamID, ok := req.Data["teamId"]; ok {
-		c.TeamID = teamID.(string)
-	} else {
+	rawTeamID, ok := req.Data["teamId"]
+	if !ok {
 		return nil, errMissingTeamInCommand
 	}
+	teamID, ok := rawTeamID.(string)
+	if !ok {
+		return nil, invalidFieldTypeError("teamId", rawTeamID)
+	}
+	c.TeamID = teamID
 
-	if readToken, ok := req.Data["readToken"]; ok {
-		c.ReadToken = readToken.(string)
+	if rawReadToken, ok := req.Data["readToken"]; ok {
+		readToken, ok := rawReadToken.(string)
+		if !ok {
+			return nil, invalidFieldTypeError("readToken", rawReadToken)
+		}
+		c.ReadToken = readToken
 	}
 
-	if blockIDs, ok := req.Data["blockIds"]; ok {
-		c.BlockIDs = blockIDs.([]string)
+	if rawBlockIDs, ok := req.Data["blockIds"]; ok {
+		rawList, ok := rawBlockIDs.([]interface{})
+		if !ok {
+			return nil, invalidFieldTypeError("blockIds", rawBlockIDs)
+		}
+		blockIDs := make([]string, 0, len(rawList))
+		for i, item := range rawList {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("%w: blockIds[%d] has type %T", errInvalidFieldType, i, item)
+			}
+			blockIDs = append(blockIDs, s)
+		}
+		c.BlockIDs = blockIDs
 	}
 
 	return c, nil
 }
 
 func (pa *PluginAdapter) WebSocketMessageHasBeenPosted(webConnID, userID string, req *mmModel.WebSocketRequest) {
+	defer func() {
+		if r := recover(); r != nil {
+			pa.logger.Error("recovered from panic in WebSocketMessageHasBeenPosted",
+				mlog.String("webConnID", webConnID),
+				mlog.String("userID", userID),
+				mlog.String("action", req.Action),
+				mlog.Any("panic", r),
+			)
+		}
+	}()
+
 	pac, ok := pa.GetListenerByWebConnID(webConnID)
 	if !ok {
 		pa.logger.Debug("received a message for an unregistered webconn",

--- a/server/ws/plugin_adapter_test.go
+++ b/server/ws/plugin_adapter_test.go
@@ -14,6 +14,96 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCommandFromRequest(t *testing.T) {
+	t.Run("rejects missing teamId", func(t *testing.T) {
+		req := &mmModel.WebSocketRequest{
+			Action: websocketMessagePrefix + websocketActionSubscribeTeam,
+			Data:   map[string]interface{}{},
+		}
+		_, err := commandFromRequest(req)
+		require.ErrorIs(t, err, errMissingTeamInCommand)
+	})
+
+	t.Run("rejects non-string teamId without panicking", func(t *testing.T) {
+		req := &mmModel.WebSocketRequest{
+			Action: websocketMessagePrefix + websocketActionSubscribeTeam,
+			Data:   map[string]interface{}{"teamId": 1.0},
+		}
+		require.NotPanics(t, func() {
+			_, err := commandFromRequest(req)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "teamId")
+		})
+	})
+
+	t.Run("rejects non-string readToken", func(t *testing.T) {
+		req := &mmModel.WebSocketRequest{
+			Action: websocketMessagePrefix + websocketActionSubscribeTeam,
+			Data:   map[string]interface{}{"teamId": "team1", "readToken": 42.0},
+		}
+		require.NotPanics(t, func() {
+			_, err := commandFromRequest(req)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "readToken")
+		})
+	})
+
+	t.Run("accepts blockIds as a JSON array of strings", func(t *testing.T) {
+		req := &mmModel.WebSocketRequest{
+			Action: websocketMessagePrefix + websocketActionSubscribeBlocks,
+			Data: map[string]interface{}{
+				"teamId":   "team1",
+				"blockIds": []interface{}{"b1", "b2"},
+			},
+		}
+		c, err := commandFromRequest(req)
+		require.NoError(t, err)
+		require.Equal(t, []string{"b1", "b2"}, c.BlockIDs)
+	})
+
+	t.Run("rejects blockIds with non-string elements", func(t *testing.T) {
+		req := &mmModel.WebSocketRequest{
+			Action: websocketMessagePrefix + websocketActionSubscribeBlocks,
+			Data: map[string]interface{}{
+				"teamId":   "team1",
+				"blockIds": []interface{}{"b1", 2.0},
+			},
+		}
+		require.NotPanics(t, func() {
+			_, err := commandFromRequest(req)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "blockIds")
+		})
+	})
+
+	t.Run("rejects blockIds that are not a JSON array", func(t *testing.T) {
+		req := &mmModel.WebSocketRequest{
+			Action: websocketMessagePrefix + websocketActionSubscribeBlocks,
+			Data: map[string]interface{}{
+				"teamId":   "team1",
+				"blockIds": "not-an-array",
+			},
+		}
+		require.NotPanics(t, func() {
+			_, err := commandFromRequest(req)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "blockIds")
+		})
+	})
+}
+
+func TestWebSocketMessageHasBeenPostedDoesNotPanicOnMalformedTeamID(t *testing.T) {
+	th := SetupTestHelper(t)
+
+	webConnID := mmModel.NewId()
+	userID := mmModel.NewId()
+	th.pa.OnWebSocketConnect(webConnID, userID)
+
+	require.NotPanics(t, func() {
+		th.ReceiveWebSocketMessage(webConnID, userID, websocketActionSubscribeTeam, map[string]interface{}{"teamId": 1.0})
+	})
+}
+
 func TestPluginAdapterTeamSubscription(t *testing.T) {
 	th := SetupTestHelper(t)
 


### PR DESCRIPTION
#### Summary
A malformed `custom_focalboard_*` WebSocket command crashed the Boards plugin process because `commandFromRequest` did unchecked Go type assertions on values pulled from a `map[string]interface{}` decoded from JSON. A JSON number for `teamId` or a JSON array for `blockIds` panicked the plugin and made Boards unavailable to all users until the plugin was restarted.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69048

#### QA
- Log into Mattermost in your browser. Open DevTools Console.
- Confirm Boards is up.
- Paste this in the console and run:
```
WebSocketClient.conn.send(JSON.stringify({
  seq: 999,
  action: 'custom_focalboard_SUBSCRIBE_TEAM',
  data: { teamId: 1 }
}));
```
- Refresh the page and reopen Boards.

Verify Boards still works fine. Server log shows a clean invalid type float64 for field "teamId" line. No panic and no plugin restart.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Low. The changes are tightly scoped to WebSocket command parsing and validation, with no impact on existing behavior for valid inputs. The `commandFromRequest` function is called only once (in `WebSocketMessageHasBeenPosted`), minimizing blast radius. Invalid inputs that previously caused panics now return descriptive errors and are logged gracefully. The defer-recover wrapper in `WebSocketMessageHasBeenPosted` provides an additional safety layer for unexpected panics. No modifications to public APIs, data structures, or authentication/authorization flows. Existing test suites remain unaffected and the changes maintain strict backward compatibility with well-formed WebSocket messages.

**QA Recommendation:** Moderate manual QA is recommended despite comprehensive automated test coverage. Focus should be on: (1) validating that legitimate WebSocket commands with well-formed JSON continue processing normally (happy path), (2) confirming malformed commands fail gracefully with appropriate logging instead of crashing the plugin, (3) stress testing repeated malformed WebSocket messages to ensure stability under adverse conditions, and (4) specifically testing the exact scenarios from the PR QA steps (malformed `teamId` as JSON number, `blockIds` as non-array) plus edge cases like empty arrays and mixed-type arrays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->