### PR TITLE
MM-69067: Revoke Board Admin from users demoted to System Guest

### DIFF
--- a/server/app/user.go
+++ b/server/app/user.go
@@ -6,6 +6,7 @@ package app
 import (
 	"github.com/mattermost/mattermost-plugin-boards/server/model"
 	mmModel "github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
 )
 
 func (a *App) GetTeamUsers(teamID string, asGuestID string) ([]*model.User, error) {
@@ -51,6 +52,41 @@ func (a *App) UserIsGuest(userID string) (bool, error) {
 		return false, err
 	}
 	return user.IsGuest, nil
+}
+
+func (a *App) RevokeBoardAdminForGuest(userID string) error {
+	if userID == "" || userID == model.SystemUserID {
+		return nil
+	}
+
+	isGuest, err := a.UserIsGuest(userID)
+	if err != nil {
+		return err
+	}
+	if !isGuest {
+		return nil
+	}
+
+	members, err := a.store.GetMembersForUser(userID)
+	if err != nil {
+		return err
+	}
+
+	for _, member := range members {
+		if !member.SchemeAdmin {
+			continue
+		}
+		updated := *member
+		updated.SchemeAdmin = false
+		if _, err := a.store.SaveMember(&updated); err != nil {
+			return err
+		}
+		a.logger.Info("revoked board admin from demoted guest",
+			mlog.String("userID", userID),
+			mlog.String("boardID", member.BoardID),
+		)
+	}
+	return nil
 }
 
 func (a *App) CanSeeUser(seerUser string, seenUser string) (bool, error) {

--- a/server/app/user_test.go
+++ b/server/app/user_test.go
@@ -6,6 +6,7 @@ package app
 import (
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/mattermost/mattermost-plugin-boards/server/model"
 	mmModel "github.com/mattermost/mattermost/server/public/model"
 	"github.com/stretchr/testify/assert"
@@ -84,5 +85,44 @@ func TestSearchUsers(t *testing.T) {
 		channels, err := th.App.SearchUserChannels(teamID, userID, "")
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(channels))
+	})
+}
+
+func TestRevokeBoardAdminForGuest(t *testing.T) {
+	th, tearDown := SetupTestHelper(t)
+	defer tearDown()
+
+	userID := "user-id-1"
+
+	t.Run("no-op for empty userID", func(t *testing.T) {
+		assert.NoError(t, th.App.RevokeBoardAdminForGuest(""))
+	})
+
+	t.Run("no-op when user is not a guest", func(t *testing.T) {
+		th.Store.EXPECT().GetUserByID(userID).Return(&model.User{ID: userID, IsGuest: false}, nil)
+
+		assert.NoError(t, th.App.RevokeBoardAdminForGuest(userID))
+	})
+
+	t.Run("clears SchemeAdmin on every membership for a guest", func(t *testing.T) {
+		members := []*model.BoardMember{
+			{BoardID: "board-1", UserID: userID, SchemeAdmin: true, SchemeEditor: true},
+			{BoardID: "board-2", UserID: userID, SchemeAdmin: false, SchemeEditor: true},
+			{BoardID: "board-3", UserID: userID, SchemeAdmin: true},
+		}
+
+		th.Store.EXPECT().GetUserByID(userID).Return(&model.User{ID: userID, IsGuest: true}, nil)
+		th.Store.EXPECT().GetMembersForUser(userID).Return(members, nil)
+
+		th.Store.EXPECT().
+			SaveMember(gomock.AssignableToTypeOf(&model.BoardMember{})).
+			DoAndReturn(func(bm *model.BoardMember) (*model.BoardMember, error) {
+				assert.False(t, bm.SchemeAdmin, "SchemeAdmin should be cleared for board %s", bm.BoardID)
+				assert.Equal(t, userID, bm.UserID)
+				return bm, nil
+			}).
+			Times(2)
+
+		assert.NoError(t, th.App.RevokeBoardAdminForGuest(userID))
 	})
 }

--- a/server/boards/boardsapp.go
+++ b/server/boards/boardsapp.go
@@ -207,6 +207,25 @@ func (b *BoardsApp) OnPluginClusterEvent(_ *plugin.Context, ev mm_model.PluginCl
 	b.wsPluginAdapter.HandleClusterEvent(ev)
 }
 
+// UserHasLoggedIn mirrors the channel behavior of clearing admin roles on
+// guest demotion. Role changes invalidate active sessions, so the next
+// login is the first authenticated event we receive after the demotion.
+// If the user is now a guest, strip SchemeAdmin from every membership so
+// that any subsequent re-promotion to member cannot resurface stale admin
+// rights. The Hooks interface in mattermost/server/public does not expose
+// UserHasBeenUpdated, so login is the earliest reliable trigger.
+func (b *BoardsApp) UserHasLoggedIn(_ *plugin.Context, user *mm_model.User) {
+	if user == nil || !user.IsGuest() {
+		return
+	}
+	if err := b.server.App().RevokeBoardAdminForGuest(user.Id); err != nil {
+		b.logger.Error("failed to revoke board admin for guest on login",
+			mlog.String("userID", user.Id),
+			mlog.Err(err),
+		)
+	}
+}
+
 // ServeHTTP demonstrates a plugin that handles HTTP requests by greeting the world.
 func (b *BoardsApp) ServeHTTP(_ *plugin.Context, w http.ResponseWriter, r *http.Request) {
 	router := b.server.GetRootRouter()

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -91,6 +91,10 @@ func (p *Plugin) MessageWillBeUpdated(ctx *plugin.Context, newPost, oldPost *mm_
 	return p.boardsApp.MessageWillBeUpdated(ctx, newPost, oldPost)
 }
 
+func (p *Plugin) UserHasLoggedIn(ctx *plugin.Context, user *mm_model.User) {
+	p.boardsApp.UserHasLoggedIn(ctx, user)
+}
+
 func (p *Plugin) RunDataRetention(nowTime, batchSize int64) (int64, error) {
 	return p.boardsApp.RunDataRetention(nowTime, batchSize)
 }

--- a/server/services/permissions/mmpermissions/helpers_test.go
+++ b/server/services/permissions/mmpermissions/helpers_test.go
@@ -41,61 +41,46 @@ func SetupTestHelper(t *testing.T) *TestHelper {
 
 func (th *TestHelper) checkBoardPermissions(roleName string, member *model.BoardMember, teamID string,
 	hasPermissionTo, hasNotPermissionTo []*mmModel.Permission) {
+	setupExpectations := func() {
+		th.store.EXPECT().
+			GetBoard(member.BoardID).
+			Return(&model.Board{ID: member.BoardID, TeamID: teamID}, nil).
+			Times(1)
+
+		th.api.EXPECT().
+			HasPermissionToTeam(member.UserID, teamID, model.PermissionViewTeam).
+			Return(true).
+			Times(1)
+
+		th.store.EXPECT().
+			GetMemberForBoard(member.BoardID, member.UserID).
+			Return(member, nil).
+			Times(1)
+
+		if member.SchemeAdmin {
+			th.store.EXPECT().
+				GetUserByID(member.UserID).
+				Return(&model.User{ID: member.UserID, IsGuest: false}, nil).
+				Times(1)
+		} else {
+			th.api.EXPECT().
+				HasPermissionToTeam(member.UserID, teamID, model.PermissionManageTeam).
+				Return(roleName == "elevated-admin").
+				Times(1)
+		}
+	}
+
 	for _, p := range hasPermissionTo {
 		th.t.Run(roleName+" "+p.Id, func(t *testing.T) {
-			th.store.EXPECT().
-				GetBoard(member.BoardID).
-				Return(&model.Board{ID: member.BoardID, TeamID: teamID}, nil).
-				Times(1)
-
-			th.api.EXPECT().
-				HasPermissionToTeam(member.UserID, teamID, model.PermissionViewTeam).
-				Return(true).
-				Times(1)
-
-			th.store.EXPECT().
-				GetMemberForBoard(member.BoardID, member.UserID).
-				Return(member, nil).
-				Times(1)
-
-			if !member.SchemeAdmin {
-				th.api.EXPECT().
-					HasPermissionToTeam(member.UserID, teamID, model.PermissionManageTeam).
-					Return(roleName == "elevated-admin").
-					Times(1)
-			}
-
-			hasPermission := th.permissions.HasPermissionToBoard(member.UserID, member.BoardID, p)
-			assert.True(t, hasPermission)
+			setupExpectations()
+			assert.True(t, th.permissions.HasPermissionToBoard(member.UserID, member.BoardID, p))
 		})
 	}
 
 	for _, p := range hasNotPermissionTo {
 		th.t.Run(roleName+" "+p.Id, func(t *testing.T) {
-			th.store.EXPECT().
-				GetBoard(member.BoardID).
-				Return(&model.Board{ID: member.BoardID, TeamID: teamID}, nil).
-				Times(1)
-
-			th.api.EXPECT().
-				HasPermissionToTeam(member.UserID, teamID, model.PermissionViewTeam).
-				Return(true).
-				Times(1)
-
-			th.store.EXPECT().
-				GetMemberForBoard(member.BoardID, member.UserID).
-				Return(member, nil).
-				Times(1)
-
-			if !member.SchemeAdmin {
-				th.api.EXPECT().
-					HasPermissionToTeam(member.UserID, teamID, model.PermissionManageTeam).
-					Return(roleName == "elevated-admin").
-					Times(1)
-			}
-
-			hasPermission := th.permissions.HasPermissionToBoard(member.UserID, member.BoardID, p)
-			assert.False(t, hasPermission)
+			setupExpectations()
+			assert.False(t, th.permissions.HasPermissionToBoard(member.UserID, member.BoardID, p))
 		})
 	}
 }

--- a/server/services/permissions/mmpermissions/mmpermissions.go
+++ b/server/services/permissions/mmpermissions/mmpermissions.go
@@ -52,6 +52,28 @@ func (s *Service) HasPermissionToChannel(userID, channelID string, permission *m
 	return s.api.HasPermissionToChannel(userID, channelID, permission)
 }
 
+// isGuest reports whether the given user must be treated as a System Guest
+// for the purpose of board admin checks. It fails closed: if the user
+// record cannot be resolved (transient DB error, missing row, etc.) the
+// caller drops any stale SchemeAdmin so that a real demotion can't be
+// bypassed by a lookup hiccup. Legitimate Team / System Admins are still
+// elevated downstream via the existing PermissionManageTeam path, so they
+// retain access to the operations they're actually entitled to.
+func (s *Service) isGuest(userID string) bool {
+	if userID == "" || userID == model.SystemUserID {
+		return false
+	}
+	user, err := s.store.GetUserByID(userID)
+	if err != nil || user == nil {
+		s.logger.Error("error getting user to evaluate guest status; treating as guest",
+			mlog.String("userID", userID),
+			mlog.Err(err),
+		)
+		return true
+	}
+	return user.IsGuest
+}
+
 func (s *Service) HasPermissionToBoard(userID, boardID string, permission *mmModel.Permission) bool {
 	if userID == "" || boardID == "" || permission == nil {
 		return false
@@ -111,6 +133,12 @@ func (s *Service) HasPermissionToBoard(userID, boardID string, permission *mmMod
 		member.SchemeCommenter = true
 	case "viewer":
 		member.SchemeViewer = true
+	}
+
+	// Guests must never hold admin rights on a board, regardless of any
+	// stale SchemeAdmin flag persisted from before they were demoted.
+	if member.SchemeAdmin && s.isGuest(userID) {
+		member.SchemeAdmin = false
 	}
 
 	// Admins become member of boards, but get minimal role

--- a/server/services/permissions/mmpermissions/mmpermissions_test.go
+++ b/server/services/permissions/mmpermissions/mmpermissions_test.go
@@ -128,8 +128,83 @@ func TestHasPermissionToBoard(t *testing.T) {
 			Return(member, nil).
 			Times(1)
 
+		th.store.EXPECT().
+			GetUserByID(userID).
+			Return(&model.User{ID: userID, IsGuest: false}, nil).
+			Times(1)
+
 		hasPermission := th.permissions.HasPermissionToBoard(member.UserID, member.BoardID, model.PermissionViewBoard)
 		assert.True(t, hasPermission)
+	})
+
+	t.Run("transient GetUserByID failure fails closed (drops stale SchemeAdmin)", func(t *testing.T) {
+		member := &model.BoardMember{
+			UserID:      userID,
+			BoardID:     boardID,
+			SchemeAdmin: true,
+		}
+
+		th.store.EXPECT().
+			GetBoard(boardID).
+			Return(&model.Board{ID: boardID, TeamID: teamID}, nil).
+			Times(1)
+		th.api.EXPECT().
+			HasPermissionToTeam(userID, teamID, model.PermissionViewTeam).
+			Return(true).
+			Times(1)
+		th.store.EXPECT().
+			GetMemberForBoard(boardID, userID).
+			Return(member, nil).
+			Times(1)
+		th.store.EXPECT().
+			GetUserByID(userID).
+			Return(nil, sql.ErrConnDone).
+			Times(1)
+		th.api.EXPECT().
+			HasPermissionToTeam(userID, teamID, model.PermissionManageTeam).
+			Return(false).
+			Times(1)
+
+		assert.False(t, th.permissions.HasPermissionToBoard(userID, boardID, model.PermissionDeleteBoard))
+	})
+
+	t.Run("guest with stale SchemeAdmin is not treated as board admin", func(t *testing.T) {
+		adminOnlyPermissions := []*mmModel.Permission{
+			model.PermissionManageBoardType,
+			model.PermissionDeleteBoard,
+			model.PermissionManageBoardRoles,
+			model.PermissionShareBoard,
+		}
+
+		for _, p := range adminOnlyPermissions {
+			member := &model.BoardMember{
+				UserID:      userID,
+				BoardID:     boardID,
+				SchemeAdmin: true,
+			}
+			th.store.EXPECT().
+				GetBoard(boardID).
+				Return(&model.Board{ID: boardID, TeamID: teamID}, nil).
+				Times(1)
+			th.api.EXPECT().
+				HasPermissionToTeam(userID, teamID, model.PermissionViewTeam).
+				Return(true).
+				Times(1)
+			th.store.EXPECT().
+				GetMemberForBoard(boardID, userID).
+				Return(member, nil).
+				Times(1)
+			th.store.EXPECT().
+				GetUserByID(userID).
+				Return(&model.User{ID: userID, IsGuest: true}, nil).
+				Times(1)
+			th.api.EXPECT().
+				HasPermissionToTeam(userID, teamID, model.PermissionManageTeam).
+				Return(false).
+				Times(1)
+
+			assert.False(t, th.permissions.HasPermissionToBoard(userID, boardID, p), p.Id)
+		}
 	})
 
 	t.Run("board admin", func(t *testing.T) {

--- a/server/services/permissions/mocks/mockstore.go
+++ b/server/services/permissions/mocks/mockstore.go
@@ -78,3 +78,18 @@ func (mr *MockStoreMockRecorder) GetMemberForBoard(arg0, arg1 interface{}) *gomo
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMemberForBoard", reflect.TypeOf((*MockStore)(nil).GetMemberForBoard), arg0, arg1)
 }
+
+// GetUserByID mocks base method.
+func (m *MockStore) GetUserByID(arg0 string) (*model.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUserByID", arg0)
+	ret0, _ := ret[0].(*model.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserByID indicates an expected call of GetUserByID.
+func (mr *MockStoreMockRecorder) GetUserByID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserByID", reflect.TypeOf((*MockStore)(nil).GetUserByID), arg0)
+}

--- a/server/services/permissions/permissions.go
+++ b/server/services/permissions/permissions.go
@@ -22,4 +22,5 @@ type Store interface {
 	GetBoard(boardID string) (*model.Board, error)
 	GetMemberForBoard(boardID, userID string) (*model.BoardMember, error)
 	GetBoardHistory(boardID string, opts model.QueryBoardHistoryOptions) ([]*model.Board, error)
+	GetUserByID(userID string) (*model.User, error)
 }


### PR DESCRIPTION
#### Summary
Aligns Boards with the channel behavior on guest demotion. Previously, when a member who held Board Admin on one or more boards was changed to System Guest the per-board SchemeAdmin flag was not reconciled with the new system role so the user's effective role on those boards did not match their new system role.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69067

#### QA
Needs one System Admin and one regular team Member on the same team.
1. As System Admin create a private board. Open Share - add the Member as Admin.
2. As the Member (second browser) open the board. Confirm admin-only UI is visible: Share dialog can change roles and board type can be changed.
3. As System Admin go to System Console - User Management - Users find the member, and change their role to Guest.
4. As the demoted user, reload Boards and reopen the same board.
Post-fix: admin-only controls are gone, the user only sees the role they actually have and any admin-gated request returns 403.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🔴 High

**Regression Risk:** Changes harden board authorization by sanitizing persisted `SchemeAdmin` when the user is (or cannot be verified as non-) a System Guest, and they add a login-time revocation path. This touches the core permission evaluation flow (hot authorization path) and extends the permissions store contract with `GetUserByID`, increasing the chance of behavioral regressions (e.g., legitimate admin users being denied if user lookups fail or are stale). The logic is security-defensive (fails closed for lookup errors), which reduces privilege-escalation risk but can still cause incorrect 403 denial if integration behavior differs from assumptions.

**QA Recommendation:** Perform focused manual security/UX verification on top of automated coverage: (1) Demote a Board Admin to System Guest and confirm all board-admin UI controls disappear (including Share dialog and board type change) immediately after login; (2) Verify admin-gated API actions (board type change, relinking channels, membership modification, board deletion) return 403 for demoted guests; (3) Verify non-demoted Board Admins retain access; (4) Confirm no transient access remains across concurrent requests during/around demotion.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->