### PR TITLE
MM-69280: Filter undefined blocks before sorting updated time/by properties

### DIFF
--- a/webapp/src/properties/latestUpdatedBlock.test.ts
+++ b/webapp/src/properties/latestUpdatedBlock.test.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {createCard} from '../blocks/card'
+import {createCommentBlock} from '../blocks/commentBlock'
+
+import {definedBlocksForLatestUpdate, getLatestUpdatedBlock} from './latestUpdatedBlock'
+
+describe('properties/latestUpdatedBlock', () => {
+    test('excludes undefined content and comment blocks before sorting', () => {
+        const card = createCard()
+        card.updateAt = Date.parse('10 Jun 2021 16:22:00')
+
+        expect(definedBlocksForLatestUpdate(card, undefined, undefined)).toEqual([card])
+    })
+
+    test('returns the block with the most recent updateAt', () => {
+        const card = createCard()
+        card.updateAt = Date.parse('10 Jun 2021 16:22:00')
+
+        const comment = createCommentBlock()
+        comment.updateAt = Date.parse('15 Jun 2021 16:22:00')
+
+        expect(getLatestUpdatedBlock(card, undefined, comment)).toBe(comment)
+    })
+})

--- a/webapp/src/properties/latestUpdatedBlock.test.ts
+++ b/webapp/src/properties/latestUpdatedBlock.test.ts
@@ -14,6 +14,13 @@ describe('properties/latestUpdatedBlock', () => {
         expect(definedBlocksForLatestUpdate(card, undefined, undefined)).toEqual([card])
     })
 
+    test('returns the card when content and comment are undefined', () => {
+        const card = createCard()
+        card.updateAt = Date.parse('10 Jun 2021 16:22:00')
+
+        expect(getLatestUpdatedBlock(card, undefined, undefined)).toBe(card)
+    })
+
     test('returns the block with the most recent updateAt', () => {
         const card = createCard()
         card.updateAt = Date.parse('10 Jun 2021 16:22:00')

--- a/webapp/src/properties/latestUpdatedBlock.ts
+++ b/webapp/src/properties/latestUpdatedBlock.ts
@@ -1,0 +1,13 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Block} from '../blocks/block'
+
+export function definedBlocksForLatestUpdate(card: Block, lastContent?: Block, lastComment?: Block): Block[] {
+    return [card, lastContent, lastComment].filter((block): block is Block => Boolean(block))
+}
+
+export function getLatestUpdatedBlock(card: Block, lastContent?: Block, lastComment?: Block): Block {
+    const allBlocks = definedBlocksForLatestUpdate(card, lastContent, lastComment)
+    return allBlocks.sort((a, b) => b.updateAt - a.updateAt)[0] ?? card
+}

--- a/webapp/src/properties/updatedBy/updatedBy.tsx
+++ b/webapp/src/properties/updatedBy/updatedBy.tsx
@@ -4,25 +4,21 @@
 
 import React from 'react'
 
-import {Block} from '../../blocks/block'
 import {useAppSelector} from '../../store/hooks'
 import {getLastCardContent} from '../../store/contents'
 import {getLastCardComment} from '../../store/comments'
+import {getLatestUpdatedBlock} from '../latestUpdatedBlock'
 import Person from '../person/person'
 
 import {PropertyProps} from '../types'
 
 const LastModifiedBy = (props: PropertyProps): JSX.Element => {
-    const lastContent = useAppSelector(getLastCardContent(props.card.id || '')) as Block
-    const lastComment = useAppSelector(getLastCardComment(props.card.id)) as Block
+    const lastContent = useAppSelector(getLastCardContent(props.card.id || ''))
+    const lastComment = useAppSelector(getLastCardComment(props.card.id))
 
-    let latestBlock: Block = props.card
-    if (props.board) {
-        const allBlocks: Block[] = [props.card, lastContent, lastComment]
-        const sortedBlocks = allBlocks.sort((a, b) => b.updateAt - a.updateAt)
-
-        latestBlock = sortedBlocks.length > 0 ? sortedBlocks[0] : latestBlock
-    }
+    const latestBlock = props.board ?
+        getLatestUpdatedBlock(props.card, lastContent, lastComment) :
+        props.card
 
     return (
         <Person

--- a/webapp/src/properties/updatedTime/updatedTime.tsx
+++ b/webapp/src/properties/updatedTime/updatedTime.tsx
@@ -6,27 +6,23 @@ import React from 'react'
 
 import {useIntl} from 'react-intl'
 
-import {Block} from '../../blocks/block'
 import {Utils} from '../../utils'
 import {useAppSelector} from '../../store/hooks'
 import {getLastCardContent} from '../../store/contents'
 import {getLastCardComment} from '../../store/comments'
+import {getLatestUpdatedBlock} from '../latestUpdatedBlock'
 import './updatedTime.scss'
 
 import {PropertyProps} from '../types'
 
 const UpdatedTime = (props: PropertyProps): JSX.Element => {
     const intl = useIntl()
-    const lastContent = useAppSelector(getLastCardContent(props.card.id || '')) as Block
-    const lastComment = useAppSelector(getLastCardComment(props.card.id)) as Block
+    const lastContent = useAppSelector(getLastCardContent(props.card.id || ''))
+    const lastComment = useAppSelector(getLastCardComment(props.card.id))
 
-    let latestBlock: Block = props.card
-    if (props.card) {
-        const allBlocks = [props.card, lastContent, lastComment]
-        const sortedBlocks = allBlocks.sort((a, b) => b.updateAt - a.updateAt)
-
-        latestBlock = sortedBlocks.length > 0 ? sortedBlocks[0] : latestBlock
-    }
+    const latestBlock = props.card ?
+        getLatestUpdatedBlock(props.card, lastContent, lastComment) :
+        props.card
 
     return (
         <div className={`UpdatedTime ${props.property.valueClassName(true)}`}>


### PR DESCRIPTION
#### Summary

Boards could crash when rendering the "Last updated time" or "Last updated by" properties on cards with no content blocks and no comments. `getLastCardContent` and `getLastCardComment` can return `undefined`, but both property components passed those values into a sort comparator that accessed `.updateAt`. This is unsafe in general and surfaced as a page crash under Chrome 149's V8 sort regression (crbug 502534423) on boards with many cards.

This change filters out undefined blocks before sorting and removes the incorrect `as Block` casts. The unit test targets that underlying condition (undefined selector results) rather than reproducing the ticket's ~500-card Chrome 149 scenario, as Jest's V8 doesn't crash when `Array.sort` encounters undefined blocks.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-69280

#### Release Note

Fixed an issue where Boards could crash when displaying the Last updated time or Last updated by property on cards with no content or comments.

#### QA

1. Create a board with the "Last updated time" property visible.
2. Add a card with no content blocks and no comments.
3. Confirm the board renders normally and the property shows the card's update time.

Optional (Chrome 149): reproduce with ~500 cards per the ticket; confirm the board no longer crashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Medium—sorting/selection logic is centralized into a new shared helper used by both “Last updated time” and “Last updated by”. While the change is localized to rendering and adds `undefined` filtering to prevent the original crash, the shared utility introduces a single dependency point and relies on consistent `updateAt` values across candidates.

**QA Recommendation:** Low-to-Medium manual QA. Verify the original crash scenario (card with no content blocks and no comments while the property is visible), plus one mixed board case (some cards with comments/content, some without) and confirm both properties still pick the newest block correctly.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->