### PR TITLE
docs: add JSDoc documentation to BoardSiteStatistics interface

### DIFF
--- a/webapp/src/statistics/index.ts
+++ b/webapp/src/statistics/index.ts
@@ -2,6 +2,11 @@
 // See LICENSE.txt for license information.
 
 
+/**
+ * Represents the statistics for a board site.
+ * @property board_count - The number of boards.
+ * @property card_count - The number of cards.
+ */
 export interface BoardSiteStatistics {
     board_count: number
     card_count: number


### PR DESCRIPTION
### 问题背景
公共接口 `BoardSiteStatistics` 缺少必要的 JSDoc 文档。添加文档有助于其他开发者快速理解接口的用途和各属性的含义，提高代码的可维护性和可读性。

### 修改内容
- **修改了什么**: 为 `webapp/src/statistics/index.ts` 中导出的 `BoardSiteStatistics` 接口添加了 JSDoc 注释。
- **为什么这样改**: 作为公共接口，明确的文档是良好工程实践的一部分。它能清楚地说明 `board_count` 和 `card_count` 这两个属性的具体含义，便于使用者理解和集成。
- **提升**: 显著提升了该接口的文档覆盖率，降低了新贡献者的理解门槛，符合开源项目对代码质量的常见要求。

### 验证方式
- 由于本次修改仅添加注释，不涉及任何逻辑变更，因此不会影响现有功能或测试。所有现有测试应继续通过。
- 无需添加新的测试用例。
- 可手动验证：在代码编辑器中查看该接口，确认 JSDoc 注释已正确显示和解析。

### 其他信息
- 本次修改没有引入任何 breaking changes。
- 无需更新其他相关文档，因为本次修改本身就是文档改进。
- 已知限制：无。