### PR TITLE
hotfix: fix failing test on main

### DIFF
--- a/server/app/helper_test.go
+++ b/server/app/helper_test.go
@@ -86,6 +86,8 @@ func (th *TestHelper) expectBoardAdmin(userID, boardID, teamID string) { //nolin
 		UserID:      userID,
 		SchemeAdmin: true,
 	}, nil)
+	// SchemeAdmin path triggers isGuest() in mmpermissions which loads the user
+	th.PermStore.EXPECT().GetUserByID(userID).Return(&model.User{ID: userID}, nil)
 }
 
 func (th *TestHelper) expectBoardEditor(userID, boardID, teamID string) {


### PR DESCRIPTION

#### Summary
Hotfix for a failing test on main introduced in PR #198


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Minimal. This is a test-only modification with zero impact on production code. The change adds a missing mock expectation to the `expectBoardAdmin` test helper to satisfy an internal code path (`isGuest()` in mmpermissions) that was previously uncovered. The modification is purely additive and does not alter any existing behavior, contracts, or public APIs. Since this is fixing a failing test rather than changing production logic, regression risk is confined to ensuring tests pass correctly.

**QA Recommendation:** Manual QA can be skipped. This is an isolated test infrastructure fix with no impact on production code, user-facing functionality, or system behavior. The change only affects unit tests in `boards_test.go` and improves test coverage by properly mocking all expected calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->