### PR TITLE
MM-69607: enforce MaxFileSize on archive import

### DIFF
--- a/server/api/archive.go
+++ b/server/api/archive.go
@@ -6,6 +6,7 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -156,9 +157,19 @@ func (a *API) handleArchiveImport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Cap the request body to MaxFileSize so an archive import cannot be used
+	// to bypass the configured upload limit
+	if maxSize := a.app.GetConfig().MaxFileSize; maxSize > 0 {
+		r.Body = http.MaxBytesReader(w, r.Body, maxSize)
+	}
+
 	file, handle, err := r.FormFile(UploadFormFileKey)
 	if err != nil {
-		fmt.Fprintf(w, "%v", err)
+		if strings.HasSuffix(err.Error(), "http: request body too large") {
+			a.errorResponse(w, r, model.ErrRequestEntityTooLarge)
+			return
+		}
+		a.errorResponse(w, r, model.NewErrBadRequest(err.Error()))
 		return
 	}
 	defer file.Close()

--- a/server/app/files.go
+++ b/server/app/files.go
@@ -46,9 +46,32 @@ func (a *App) SaveFile(reader io.Reader, teamID, boardID, filename string, asTem
 		return "", fmt.Errorf("invalid file path parameters: %w", pathErr)
 	}
 
-	fileSize, appErr := a.filesBackend.WriteFile(reader, filePath)
+	// Enforce MaxFileSize on every write path so a
+	// crafted archive cannot bypass the configured limit.
+	var writeReader io.Reader = reader
+	var maxSize int64
+	if a.config != nil {
+		maxSize = a.config.MaxFileSize
+	}
+	if maxSize > 0 {
+		writeReader = io.LimitReader(reader, maxSize+1)
+	}
+
+	fileSize, appErr := a.filesBackend.WriteFile(writeReader, filePath)
 	if appErr != nil {
+		if rmErr := a.filesBackend.RemoveFile(filePath); rmErr != nil {
+			a.logger.Error("SaveFile: failed to remove partial file after write error",
+				mlog.String("path", filePath), mlog.Err(rmErr))
+		}
 		return "", fmt.Errorf("unable to store the file in the files storage: %w", appErr)
+	}
+
+	if maxSize > 0 && fileSize > maxSize {
+		if rmErr := a.filesBackend.RemoveFile(filePath); rmErr != nil {
+			a.logger.Error("SaveFile: failed to remove oversized file",
+				mlog.String("path", filePath), mlog.Err(rmErr))
+		}
+		return "", model.ErrRequestEntityTooLarge
 	}
 
 	fileInfo := model.NewFileInfo(filename)

--- a/server/app/files_test.go
+++ b/server/app/files_test.go
@@ -269,6 +269,7 @@ func TestSaveFile(t *testing.T) {
 		}
 
 		mockedFileBackend.On("WriteFile", mockedReadCloseSeek, mock.Anything).Return(writeFileFunc, writeFileErrorFunc)
+		mockedFileBackend.On("RemoveFile", mock.Anything).Return(nil)
 		actual, err := th.App.SaveFile(mockedReadCloseSeek, validTeamID, validBoardID, fileName, false)
 		assert.Equal(t, "", actual)
 		assert.Equal(t, "unable to store the file in the files storage: Mocked File backend error", err.Error())

--- a/server/app/files_test.go
+++ b/server/app/files_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/mattermost/mattermost-plugin-boards/server/model"
+	"github.com/mattermost/mattermost-plugin-boards/server/services/config"
 	"github.com/mattermost/mattermost-plugin-boards/server/utils"
 	mm_model "github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest/mock"
@@ -273,6 +274,66 @@ func TestSaveFile(t *testing.T) {
 		actual, err := th.App.SaveFile(mockedReadCloseSeek, validTeamID, validBoardID, fileName, false)
 		assert.Equal(t, "", actual)
 		assert.Equal(t, "unable to store the file in the files storage: Mocked File backend error", err.Error())
+	})
+
+	t.Run("should reject file that exceeds configured MaxFileSize", func(t *testing.T) {
+		fileName := "oversize.txt"
+		validTeamID := mm_model.NewId()
+		validBoardID := utils.NewID(utils.IDTypeBoard)
+		mockedFileBackend := &mocks.FileBackend{}
+		th.App.filesBackend = mockedFileBackend
+		th.App.SetConfig(&config.Configuration{MaxFileSize: 10})
+
+		writeFileFunc := func(reader io.Reader, path string) int64 { return int64(11) }
+		writeFileErrorFunc := func(reader io.Reader, filePath string) error { return nil }
+		mockedFileBackend.On("WriteFile", mock.Anything, mock.Anything).Return(writeFileFunc, writeFileErrorFunc)
+		mockedFileBackend.On("RemoveFile", mock.Anything).Return(nil)
+
+		actual, err := th.App.SaveFile(mockedReadCloseSeek, validTeamID, validBoardID, fileName, false)
+		assert.Equal(t, "", actual)
+		assert.Error(t, err)
+		assert.True(t, model.IsErrRequestEntityTooLarge(err), "expected ErrRequestEntityTooLarge, got: %v", err)
+		mockedFileBackend.AssertCalled(t, "RemoveFile", mock.Anything)
+	})
+
+	t.Run("should accept file within configured MaxFileSize", func(t *testing.T) {
+		fileName := "within-limit.txt"
+		validTeamID := mm_model.NewId()
+		validBoardID := utils.NewID(utils.IDTypeBoard)
+		mockedFileBackend := &mocks.FileBackend{}
+		th.App.filesBackend = mockedFileBackend
+		th.App.SetConfig(&config.Configuration{MaxFileSize: 100})
+
+		th.Store.EXPECT().SaveFileInfo(gomock.Any()).Return(nil)
+
+		writeFileFunc := func(reader io.Reader, path string) int64 { return int64(50) }
+		writeFileErrorFunc := func(reader io.Reader, filePath string) error { return nil }
+		mockedFileBackend.On("WriteFile", mock.Anything, mock.Anything).Return(writeFileFunc, writeFileErrorFunc)
+
+		actual, err := th.App.SaveFile(mockedReadCloseSeek, validTeamID, validBoardID, fileName, false)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, actual)
+		mockedFileBackend.AssertNotCalled(t, "RemoveFile", mock.Anything)
+	})
+
+	t.Run("should accept any file size when MaxFileSize is zero (no limit)", func(t *testing.T) {
+		fileName := "no-limit.txt"
+		validTeamID := mm_model.NewId()
+		validBoardID := utils.NewID(utils.IDTypeBoard)
+		mockedFileBackend := &mocks.FileBackend{}
+		th.App.filesBackend = mockedFileBackend
+		th.App.SetConfig(&config.Configuration{MaxFileSize: 0})
+
+		th.Store.EXPECT().SaveFileInfo(gomock.Any()).Return(nil)
+
+		writeFileFunc := func(reader io.Reader, path string) int64 { return int64(1024 * 1024 * 500) }
+		writeFileErrorFunc := func(reader io.Reader, filePath string) error { return nil }
+		mockedFileBackend.On("WriteFile", mockedReadCloseSeek, mock.Anything).Return(writeFileFunc, writeFileErrorFunc)
+
+		actual, err := th.App.SaveFile(mockedReadCloseSeek, validTeamID, validBoardID, fileName, false)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, actual)
+		mockedFileBackend.AssertNotCalled(t, "RemoveFile", mock.Anything)
 	})
 }
 

--- a/server/integrationtests/permissions_test.go
+++ b/server/integrationtests/permissions_test.go
@@ -2831,11 +2831,11 @@ func TestPermissionsBoardArchiveImport(t *testing.T) {
 	ttCases := []TestCase{
 		{"/teams/test-team/archive/import", methodPost, "", userAnon, http.StatusUnauthorized, 0},
 		{"/teams/test-team/archive/import", methodPost, "", userNoTeamMember, http.StatusForbidden, 1},
-		{"/teams/test-team/archive/import", methodPost, "", userTeamMember, http.StatusOK, 1},
-		{"/teams/test-team/archive/import", methodPost, "", userViewer, http.StatusOK, 1},
-		{"/teams/test-team/archive/import", methodPost, "", userCommenter, http.StatusOK, 1},
-		{"/teams/test-team/archive/import", methodPost, "", userEditor, http.StatusOK, 1},
-		{"/teams/test-team/archive/import", methodPost, "", userAdmin, http.StatusOK, 1},
+		{"/teams/test-team/archive/import", methodPost, "", userTeamMember, http.StatusBadRequest, 1},
+		{"/teams/test-team/archive/import", methodPost, "", userViewer, http.StatusBadRequest, 1},
+		{"/teams/test-team/archive/import", methodPost, "", userCommenter, http.StatusBadRequest, 1},
+		{"/teams/test-team/archive/import", methodPost, "", userEditor, http.StatusBadRequest, 1},
+		{"/teams/test-team/archive/import", methodPost, "", userAdmin, http.StatusBadRequest, 1},
 		{"/teams/test-team/archive/import", methodPost, "", userGuest, http.StatusForbidden, 0},
 	}
 


### PR DESCRIPTION
#### Summary
MM-69607 Boards archive import bypasses MaxFileSize. Any authenticated user could write files of any size to the storage backend by importing a crafted archive exhausting disk and taking the whole instance down.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69607



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The fix spans archive import handling and shared file-saving logic, so it affects a user-facing upload path and related error handling. The new size enforcement changes write behavior and cleanup paths, which could surface regressions around oversized files or partial write failures, but the impact is mostly contained and rollback should be straightforward.

**QA Recommendation:** Moderate QA is recommended. Prioritize validating archive imports at, below, and above `MaxFileSize`, plus confirming normal file saves still work and oversized uploads return the expected error.
*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->