### PR TITLE
MM-69622 Refactoring board validators

### DIFF
--- a/server/api/archive.go
+++ b/server/api/archive.go
@@ -175,6 +175,9 @@ func (a *API) handleArchiveImport(w http.ResponseWriter, r *http.Request) {
 	opt := model.ImportArchiveOptions{
 		TeamID:     teamID,
 		ModifiedBy: userID,
+		BoardValidator: func(board *model.Board) error {
+			return a.authorizeBoardCreate(userID, teamID, board.Type)
+		},
 	}
 
 	if err := a.app.ImportArchive(file, opt); err != nil {

--- a/server/api/boards.go
+++ b/server/api/boards.go
@@ -549,6 +549,11 @@ func (a *API) handleDuplicateBoard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err = a.authorizeBoardCreate(userID, toTeam, model.BoardTypePrivate); err != nil {
+		a.errorResponse(w, r, err)
+		return
+	}
+
 	auditRec := a.makeAuditRecord(r, "duplicateBoard", audit.Fail)
 	defer a.audit.LogRecord(audit.LevelRead, auditRec)
 	auditRec.AddMeta("boardID", boardID)

--- a/server/api/boards.go
+++ b/server/api/boards.go
@@ -26,6 +26,24 @@ func (a *API) registerBoardsRoutes(r *mux.Router) {
 	r.HandleFunc("/boards/{boardID}/metadata", a.sessionRequired(a.handleGetBoardMetadata)).Methods("GET")
 }
 
+// authorizeBoardCreate enforces the per-type board creation policy: creating a
+// public board requires the create_public_channel team permission, and creating
+// any other board type requires create_private_channel. It is shared across all
+// board creation paths so the policy is enforced consistently.
+func (a *API) authorizeBoardCreate(userID, teamID string, boardType model.BoardType) error {
+	if boardType == model.BoardTypeOpen {
+		if !a.permissions.HasPermissionToTeam(userID, teamID, model.PermissionCreatePublicChannel) {
+			return model.NewErrPermission("access denied to create public boards")
+		}
+	} else {
+		if !a.permissions.HasPermissionToTeam(userID, teamID, model.PermissionCreatePrivateChannel) {
+			return model.NewErrPermission("access denied to create private boards")
+		}
+	}
+
+	return nil
+}
+
 func (a *API) authorizeBoardPatch(userID, boardID string, patch *model.BoardPatch) error {
 	if !a.permissions.HasPermissionToBoard(userID, boardID, model.PermissionManageBoardProperties) {
 		return model.NewErrPermission("access denied to modifying board properties")
@@ -163,16 +181,9 @@ func (a *API) handleCreateBoard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if newBoard.Type == model.BoardTypeOpen {
-		if !a.permissions.HasPermissionToTeam(userID, newBoard.TeamID, model.PermissionCreatePublicChannel) {
-			a.errorResponse(w, r, model.NewErrPermission("access denied to create public boards"))
-			return
-		}
-	} else {
-		if !a.permissions.HasPermissionToTeam(userID, newBoard.TeamID, model.PermissionCreatePrivateChannel) {
-			a.errorResponse(w, r, model.NewErrPermission("access denied to create private boards"))
-			return
-		}
+	if err = a.authorizeBoardCreate(userID, newBoard.TeamID, newBoard.Type); err != nil {
+		a.errorResponse(w, r, err)
+		return
 	}
 
 	isGuest, err := a.userIsGuest(userID)

--- a/server/api/boards_and_blocks.go
+++ b/server/api/boards_and_blocks.go
@@ -110,6 +110,13 @@ func (a *API) handleCreateBoardsAndBlocks(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	for _, board := range newBab.Boards {
+		if err = a.authorizeBoardCreate(userID, board.TeamID, board.Type); err != nil {
+			a.errorResponse(w, r, err)
+			return
+		}
+	}
+
 	for _, block := range newBab.Blocks {
 		// Error checking
 		if len(block.Type) < 1 {

--- a/server/app/import.go
+++ b/server/app/import.go
@@ -293,7 +293,7 @@ func (a *App) parseBoardsAndBlocks(r io.Reader, opt model.ImportArchiveOptions) 
 					block.UpdateAt = now
 					board, err := a.blockToBoard(block, opt)
 					if err != nil {
-						return nil, nil, fmt.Errorf("cannot convert archive line %d to block: %w", lineNum, err)
+						return nil, nil, fmt.Errorf("cannot convert archive line %d to board: %w", lineNum, err)
 					}
 					if err := board.IsValidForImport(); err != nil {
 						return nil, nil, err

--- a/server/app/import.go
+++ b/server/app/import.go
@@ -110,6 +110,20 @@ func (a *App) ImportArchive(r io.Reader, opt model.ImportArchiveOptions) error {
 	}
 }
 
+// validateImportedBoards runs the optional authorization callback against every
+// board parsed from an archive, aborting the import if any board is rejected.
+func validateImportedBoards(boards []*model.Board, validator model.BoardValidator) error {
+	if validator == nil {
+		return nil
+	}
+	for _, board := range boards {
+		if err := validator(board); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Update image and attachment blocks.
 func (a *App) fixImagesAttachments(boardMap map[string]*model.Board, fileMap map[string]string, teamID string, userID string) {
 	for _, board := range boardMap {
@@ -253,6 +267,11 @@ func (a *App) ImportBoardJSONL(r io.Reader, opt model.ImportArchiveOptions) (*mo
 
 	if errRead := scanner.Err(); errRead != nil {
 		return nil, fmt.Errorf("error reading archive line %d: %w", lineNum, errRead)
+	}
+
+	// enforce authorization for every board before anything is persisted
+	if err := validateImportedBoards(boardsAndBlocks.Boards, opt.BoardValidator); err != nil {
+		return nil, err
 	}
 
 	// loop to remove the people how are not part of the team and system

--- a/server/app/import.go
+++ b/server/app/import.go
@@ -29,8 +29,9 @@ const (
 )
 
 var (
-	errBlockIsNotABoard  = errors.New("block is not a board")
-	errSizeLimitExceeded = errors.New("size limit exceeded")
+	errBlockIsNotABoard   = errors.New("block is not a board")
+	errSizeLimitExceeded  = errors.New("size limit exceeded")
+	errArchiveNotSeekable = errors.New("cannot import archive: reader must support seeking to validate boards")
 )
 
 // ImportArchive imports an archive containing zero or more boards, plus all
@@ -39,6 +40,66 @@ var (
 // Archives are ZIP files containing a `version.json` file and zero or more
 // directories, each containing a `board.jsonl` and zero or more image files.
 func (a *App) ImportArchive(r io.Reader, opt model.ImportArchiveOptions) error {
+	// When a board validator is provided, authorize every board in the archive
+	// before persisting anything. The archive is imported as a stream that
+	// commits board-by-board, so validation runs as a dedicated first pass and
+	// the reader is rewound before the real import.
+	if opt.BoardValidator != nil {
+		if err := a.validateArchiveBoards(r, opt); err != nil {
+			return err
+		}
+		seeker, ok := r.(io.Seeker)
+		if !ok {
+			return errArchiveNotSeekable
+		}
+		if _, err := seeker.Seek(0, io.SeekStart); err != nil {
+			return fmt.Errorf("cannot rewind archive after board validation: %w", err)
+		}
+	}
+
+	return a.importArchive(r, opt)
+}
+
+// validateArchiveBoards authorizes every board contained in the archive without
+// persisting anything, so a single rejected board aborts the whole import
+// before any board is created.
+func (a *App) validateArchiveBoards(r io.Reader, opt model.ImportArchiveOptions) error {
+	br := bufio.NewReader(r)
+	peek, err := br.Peek(len(legacyFileBegin))
+	if err == nil && string(peek) == legacyFileBegin {
+		bab, _, parseErr := a.parseBoardsAndBlocks(br, opt)
+		if parseErr != nil {
+			return parseErr
+		}
+		return validateImportedBoards(bab.Boards, opt.BoardValidator)
+	}
+
+	zr := zipstream.NewReader(br)
+	for {
+		hdr, err := zr.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+
+		dir, filename := filepath.Split(hdr.Name)
+		if filename != "board.jsonl" {
+			continue
+		}
+
+		bab, _, parseErr := a.parseBoardsAndBlocks(zr, opt)
+		if parseErr != nil {
+			return fmt.Errorf("cannot import board %s: %w", path.Clean(dir), parseErr)
+		}
+		if err := validateImportedBoards(bab.Boards, opt.BoardValidator); err != nil {
+			return err
+		}
+	}
+}
+
+func (a *App) importArchive(r io.Reader, opt model.ImportArchiveOptions) error {
 	// peek at the first bytes to see if this is a legacy archive format
 	br := bufio.NewReader(r)
 	peek, err := br.Peek(len(legacyFileBegin))
@@ -166,9 +227,9 @@ func (a *App) fixImagesAttachments(boardMap map[string]*model.Board, fileMap map
 	}
 }
 
-// ImportBoardJSONL imports a JSONL file containing blocks for one board. The resulting
-// board id is returned.
-func (a *App) ImportBoardJSONL(r io.Reader, opt model.ImportArchiveOptions) (*model.Board, error) {
+// parseBoardsAndBlocks parses a JSONL file describing one board into its boards,
+// blocks, and members without persisting anything.
+func (a *App) parseBoardsAndBlocks(r io.Reader, opt model.ImportArchiveOptions) (*model.BoardsAndBlocks, []*model.BoardMember, error) {
 	// TODO: Stream this once `model.GenerateBlockIDs` can take a stream of blocks.
 	//       We don't want to load the whole file in memory, even though it's a single board.
 	boardsAndBlocks := &model.BoardsAndBlocks{
@@ -187,7 +248,7 @@ func (a *App) ImportBoardJSONL(r io.Reader, opt model.ImportArchiveOptions) (*mo
 	firstLine := true
 	for scanner.Scan() {
 		if lineReader.N <= 0 {
-			return nil, fmt.Errorf("error parsing archive line %d: %w", lineNum, errSizeLimitExceeded)
+			return nil, nil, fmt.Errorf("error parsing archive line %d: %w", lineNum, errSizeLimitExceeded)
 		}
 
 		line := bytes.TrimSpace(scanner.Bytes())
@@ -203,7 +264,7 @@ func (a *App) ImportBoardJSONL(r io.Reader, opt model.ImportArchiveOptions) (*mo
 			if !skip {
 				var archiveLine model.ArchiveLine
 				if err := json.Unmarshal(line, &archiveLine); err != nil {
-					return nil, fmt.Errorf("error parsing archive line %d: %w", lineNum, err)
+					return nil, nil, fmt.Errorf("error parsing archive line %d: %w", lineNum, err)
 				}
 
 				// first line must be a board
@@ -215,7 +276,7 @@ func (a *App) ImportBoardJSONL(r io.Reader, opt model.ImportArchiveOptions) (*mo
 				case "board":
 					var board model.Board
 					if err2 := json.Unmarshal(archiveLine.Data, &board); err2 != nil {
-						return nil, fmt.Errorf("invalid board in archive line %d: %w", lineNum, err2)
+						return nil, nil, fmt.Errorf("invalid board in archive line %d: %w", lineNum, err2)
 					}
 					board.ModifiedBy = userID
 					board.UpdateAt = now
@@ -226,26 +287,26 @@ func (a *App) ImportBoardJSONL(r io.Reader, opt model.ImportArchiveOptions) (*mo
 					// legacy archives encoded boards as blocks; we need to convert them to real boards.
 					var block *model.Block
 					if err2 := json.Unmarshal(archiveLine.Data, &block); err2 != nil {
-						return nil, fmt.Errorf("invalid board block in archive line %d: %w", lineNum, err2)
+						return nil, nil, fmt.Errorf("invalid board block in archive line %d: %w", lineNum, err2)
 					}
 					block.ModifiedBy = userID
 					block.UpdateAt = now
 					board, err := a.blockToBoard(block, opt)
 					if err != nil {
-						return nil, fmt.Errorf("cannot convert archive line %d to block: %w", lineNum, err)
+						return nil, nil, fmt.Errorf("cannot convert archive line %d to block: %w", lineNum, err)
 					}
 					if err := board.IsValidForImport(); err != nil {
-						return nil, err
+						return nil, nil, err
 					}
 					boardsAndBlocks.Boards = append(boardsAndBlocks.Boards, board)
 					boardID = board.ID
 				case "block":
 					var block *model.Block
 					if err2 := json.Unmarshal(archiveLine.Data, &block); err2 != nil {
-						return nil, fmt.Errorf("invalid block in archive line %d: %w", lineNum, err2)
+						return nil, nil, fmt.Errorf("invalid block in archive line %d: %w", lineNum, err2)
 					}
 					if err := block.IsValidForImport(); err != nil {
-						return nil, err
+						return nil, nil, err
 					}
 					block.ModifiedBy = userID
 					block.UpdateAt = now
@@ -254,11 +315,11 @@ func (a *App) ImportBoardJSONL(r io.Reader, opt model.ImportArchiveOptions) (*mo
 				case "boardMember":
 					var boardMember *model.BoardMember
 					if err2 := json.Unmarshal(archiveLine.Data, &boardMember); err2 != nil {
-						return nil, fmt.Errorf("invalid board Member in archive line %d: %w", lineNum, err2)
+						return nil, nil, fmt.Errorf("invalid board Member in archive line %d: %w", lineNum, err2)
 					}
 					boardMembers = append(boardMembers, boardMember)
 				default:
-					return nil, model.NewErrUnsupportedArchiveLineType(lineNum, archiveLine.Type)
+					return nil, nil, model.NewErrUnsupportedArchiveLineType(lineNum, archiveLine.Type)
 				}
 				firstLine = false
 			}
@@ -266,24 +327,30 @@ func (a *App) ImportBoardJSONL(r io.Reader, opt model.ImportArchiveOptions) (*mo
 	}
 
 	if errRead := scanner.Err(); errRead != nil {
-		return nil, fmt.Errorf("error reading archive line %d: %w", lineNum, errRead)
+		return nil, nil, fmt.Errorf("error reading archive line %d: %w", lineNum, errRead)
 	}
 
-	// enforce authorization for every board before anything is persisted
-	if err := validateImportedBoards(boardsAndBlocks.Boards, opt.BoardValidator); err != nil {
+	return boardsAndBlocks, boardMembers, nil
+}
+
+// ImportBoardJSONL imports a JSONL file containing blocks for one board. The resulting
+// board id is returned. Board authorization is expected to have already run via
+// ImportArchive; this persists the parsed board without re-validating it.
+func (a *App) ImportBoardJSONL(r io.Reader, opt model.ImportArchiveOptions) (*model.Board, error) {
+	boardsAndBlocks, boardMembers, err := a.parseBoardsAndBlocks(r, opt)
+	if err != nil {
 		return nil, err
 	}
 
 	// loop to remove the people how are not part of the team and system
 	for i := len(boardMembers) - 1; i >= 0; i-- {
-		if _, err := a.GetUser(boardMembers[i].UserID); err != nil {
+		if _, getErr := a.GetUser(boardMembers[i].UserID); getErr != nil {
 			boardMembers = append(boardMembers[:i], boardMembers[i+1:]...)
 		}
 	}
 
 	a.fixBoardsandBlocks(boardsAndBlocks, opt)
 
-	var err error
 	boardsAndBlocks, err = model.GenerateBoardsAndBlocksIDs(boardsAndBlocks, a.logger)
 	if err != nil {
 		return nil, fmt.Errorf("error generating archive block IDs: %w", err)

--- a/server/app/import_test.go
+++ b/server/app/import_test.go
@@ -4,7 +4,10 @@
 package app
 
 import (
+	"archive/zip"
 	"bytes"
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/mattermost/mattermost-plugin-boards/server/utils"
@@ -185,25 +188,55 @@ func TestApp_ImportArchive(t *testing.T) {
 	})
 
 	t.Run("board validator aborts import before any board is created", func(t *testing.T) {
-		r := bytes.NewReader([]byte(boardArchive))
+		r := bytes.NewReader([]byte(asana))
 
 		validatorErr := model.NewErrPermission("access denied to create private boards")
 		var validated []*model.Board
 		opts := model.ImportArchiveOptions{
-			TeamID:     "test-team",
-			ModifiedBy: "f1tydgc697fcbp8ampr6881jea",
+			TeamID:     "y5tuzz9yb3y99gmobyc4hg5wnr",
+			ModifiedBy: "user",
 			BoardValidator: func(board *model.Board) error {
 				validated = append(validated, board)
 				return validatorErr
 			},
 		}
 
-		// No store mutations should be expected: the validator must fail the
-		// import before CreateBoardsAndBlocks is ever reached.
-		_, err := th.App.ImportBoardJSONL(r, opts)
+		// No store mutations should be expected: the validator runs during the
+		// dedicated pre-pass in ImportArchive and must fail the import before
+		// CreateBoardsAndBlocks is ever reached.
+		err := th.App.ImportArchive(r, opts)
 		require.ErrorIs(t, err, validatorErr)
 		require.Len(t, validated, 1)
 		require.Equal(t, model.BoardTypePrivate, validated[0].Type)
+	})
+
+	t.Run("multi-board archive is not partially imported when a later board is denied", func(t *testing.T) {
+		// The archive contains an allowed public board followed by a denied
+		// private board. Validation happens up front for the whole archive, so
+		// neither board must be persisted (no CreateBoardsAndBlocks is expected
+		// on the mock store).
+		archive := buildBoardArchive(t,
+			&model.Board{ID: "board-open", Title: "Open", Type: model.BoardTypeOpen},
+			&model.Board{ID: "board-private", Title: "Private", Type: model.BoardTypePrivate},
+		)
+
+		validatorErr := model.NewErrPermission("access denied to create private boards")
+		var validated []model.BoardType
+		opts := model.ImportArchiveOptions{
+			TeamID:     "test-team",
+			ModifiedBy: "user",
+			BoardValidator: func(board *model.Board) error {
+				validated = append(validated, board.Type)
+				if board.Type != model.BoardTypeOpen {
+					return validatorErr
+				}
+				return nil
+			},
+		}
+
+		err := th.App.ImportArchive(bytes.NewReader(archive), opts)
+		require.ErrorIs(t, err, validatorErr)
+		require.Equal(t, []model.BoardType{model.BoardTypeOpen, model.BoardTypePrivate}, validated)
 	})
 
 	t.Run("fix image and attachment", func(t *testing.T) {
@@ -267,6 +300,42 @@ func TestApp_ImportArchive(t *testing.T) {
 		th.Store.EXPECT().PatchBlocks(gomock.Any(), "my-userid").Return(nil)
 		th.App.fixImagesAttachments(boardMap, fileMap, "test-team", "my-userid")
 	})
+}
+
+// buildBoardArchive builds an in-memory .boardarchive zip containing a
+// version.json and one board.jsonl entry per board, in order.
+func buildBoardArchive(t *testing.T, boards ...*model.Board) []byte {
+	t.Helper()
+
+	buf := &bytes.Buffer{}
+	zw := zip.NewWriter(buf)
+
+	header, err := json.Marshal(model.ArchiveHeader{Version: archiveVersion, Date: utils.GetMillis()})
+	require.NoError(t, err)
+	versionWriter, err := zw.Create("version.json")
+	require.NoError(t, err)
+	_, err = versionWriter.Write(header)
+	require.NoError(t, err)
+
+	for i, board := range boards {
+		line, err := json.Marshal(model.ArchiveLine{Type: "board", Data: mustMarshal(t, board)})
+		require.NoError(t, err)
+
+		boardWriter, err := zw.Create(fmt.Sprintf("board-%d/board.jsonl", i))
+		require.NoError(t, err)
+		_, err = boardWriter.Write(append(line, '\n'))
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+func mustMarshal(t *testing.T, v interface{}) json.RawMessage {
+	t.Helper()
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	return data
 }
 
 //nolint:lll

--- a/server/app/import_test.go
+++ b/server/app/import_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/mattermost/mattermost-plugin-boards/server/utils"
@@ -208,6 +209,28 @@ func TestApp_ImportArchive(t *testing.T) {
 		require.ErrorIs(t, err, validatorErr)
 		require.Len(t, validated, 1)
 		require.Equal(t, model.BoardTypePrivate, validated[0].Type)
+	})
+
+	t.Run("board validator with non-seekable reader fails before import", func(t *testing.T) {
+		// The validator passes, but the reader cannot be rewound for the real
+		// import pass, so the import must abort with errArchiveNotSeekable and
+		// never persist anything (no CreateBoardsAndBlocks on the mock store).
+		var validated []*model.Board
+		opts := model.ImportArchiveOptions{
+			TeamID:     "y5tuzz9yb3y99gmobyc4hg5wnr",
+			ModifiedBy: "user",
+			BoardValidator: func(board *model.Board) error {
+				validated = append(validated, board)
+				return nil
+			},
+		}
+
+		// struct{ io.Reader } hides bytes.Reader's Seek method.
+		r := struct{ io.Reader }{bytes.NewReader([]byte(asana))}
+
+		err := th.App.ImportArchive(r, opts)
+		require.ErrorIs(t, err, errArchiveNotSeekable)
+		require.Len(t, validated, 1)
 	})
 
 	t.Run("multi-board archive is not partially imported when a later board is denied", func(t *testing.T) {

--- a/server/app/import_test.go
+++ b/server/app/import_test.go
@@ -184,6 +184,28 @@ func TestApp_ImportArchive(t *testing.T) {
 		require.Equal(t, board.ID, newBoard.ID)
 	})
 
+	t.Run("board validator aborts import before any board is created", func(t *testing.T) {
+		r := bytes.NewReader([]byte(boardArchive))
+
+		validatorErr := model.NewErrPermission("access denied to create private boards")
+		var validated []*model.Board
+		opts := model.ImportArchiveOptions{
+			TeamID:     "test-team",
+			ModifiedBy: "f1tydgc697fcbp8ampr6881jea",
+			BoardValidator: func(board *model.Board) error {
+				validated = append(validated, board)
+				return validatorErr
+			},
+		}
+
+		// No store mutations should be expected: the validator must fail the
+		// import before CreateBoardsAndBlocks is ever reached.
+		_, err := th.App.ImportBoardJSONL(r, opts)
+		require.ErrorIs(t, err, validatorErr)
+		require.Len(t, validated, 1)
+		require.Equal(t, model.BoardTypePrivate, validated[0].Type)
+	})
+
 	t.Run("fix image and attachment", func(t *testing.T) {
 		boardMap := map[string]*model.Board{
 			"test": board,

--- a/server/integrationtests/board_creation_permissions_test.go
+++ b/server/integrationtests/board_creation_permissions_test.go
@@ -16,8 +16,8 @@ import (
 // TestBoardCreationPermissionEnforcement verifies that the per-type board
 // creation permission (create_public_channel / create_private_channel) is
 // enforced consistently across every board creation endpoint, guarding against
-// a regression where /boards-and-blocks and the archive import endpoints
-// skipped the check (MM-69622).
+// a regression where /boards-and-blocks, the archive import, and the board
+// duplicate endpoints skipped the check (MM-69622).
 func TestBoardCreationPermissionEnforcement(t *testing.T) {
 	t.Run("createBoard honors revoked create permissions", func(t *testing.T) {
 		th := SetupTestHelperPluginMode(t)
@@ -65,6 +65,26 @@ func TestBoardCreationPermissionEnforcement(t *testing.T) {
 		th.PermissionAPI.DenyTeamPermission(userTeamMember, model.PermissionCreatePublicChannel)
 
 		_, resp = th.Client.CreateBoardsAndBlocks(newBoardAndBlocks(teamID, model.BoardTypeOpen))
+		th.CheckForbidden(resp)
+	})
+
+	t.Run("duplicateBoard honors revoked create permissions", func(t *testing.T) {
+		th := SetupTestHelperPluginMode(t)
+		defer th.TearDown()
+		clients := setupClients(th)
+		th.Client = clients.TeamMember
+
+		teamID := mmModel.NewId()
+
+		// Duplicated boards are always created as private, so revoking the
+		// private create permission must block duplication.
+		source, resp := th.Client.CreateBoardsAndBlocks(newBoardAndBlocks(teamID, model.BoardTypeOpen))
+		th.CheckOK(resp)
+		require.Len(t, source.Boards, 1)
+
+		th.PermissionAPI.DenyTeamPermission(userTeamMember, model.PermissionCreatePrivateChannel)
+
+		_, resp = th.Client.DuplicateBoard(source.Boards[0].ID, false, teamID)
 		th.CheckForbidden(resp)
 	})
 

--- a/server/integrationtests/board_creation_permissions_test.go
+++ b/server/integrationtests/board_creation_permissions_test.go
@@ -51,6 +51,12 @@ func TestBoardCreationPermissionEnforcement(t *testing.T) {
 		_, resp := th.Client.CreateBoardsAndBlocks(newBoardAndBlocks(teamID, model.BoardTypePrivate))
 		th.CheckForbidden(resp)
 
+		// A batch mixing an allowed public board with a denied private board
+		// must be rejected as a whole: a single unauthorized board fails the
+		// entire request.
+		_, resp = th.Client.CreateBoardsAndBlocks(newBoardsAndBlocks(teamID, model.BoardTypeOpen, model.BoardTypePrivate))
+		th.CheckForbidden(resp)
+
 		bab, resp := th.Client.CreateBoardsAndBlocks(newBoardAndBlocks(teamID, model.BoardTypeOpen))
 		th.CheckOK(resp)
 		require.Len(t, bab.Boards, 1)
@@ -88,21 +94,27 @@ func TestBoardCreationPermissionEnforcement(t *testing.T) {
 }
 
 func newBoardAndBlocks(teamID string, boardType model.BoardType) *model.BoardsAndBlocks {
-	boardID := utils.NewID(utils.IDTypeBoard)
-	return &model.BoardsAndBlocks{
-		Boards: []*model.Board{{
+	return newBoardsAndBlocks(teamID, boardType)
+}
+
+func newBoardsAndBlocks(teamID string, boardTypes ...model.BoardType) *model.BoardsAndBlocks {
+	bab := &model.BoardsAndBlocks{}
+	for _, boardType := range boardTypes {
+		boardID := utils.NewID(utils.IDTypeBoard)
+		bab.Boards = append(bab.Boards, &model.Board{
 			ID:     boardID,
 			Title:  "Test Board",
 			TeamID: teamID,
 			Type:   boardType,
-		}},
-		Blocks: []*model.Block{{
+		})
+		bab.Blocks = append(bab.Blocks, &model.Block{
 			ID:       utils.NewID(utils.IDTypeCard),
 			Title:    "Test Block",
 			BoardID:  boardID,
 			Type:     model.TypeCard,
 			CreateAt: model.GetMillis(),
 			UpdateAt: model.GetMillis(),
-		}},
+		})
 	}
+	return bab
 }

--- a/server/integrationtests/board_creation_permissions_test.go
+++ b/server/integrationtests/board_creation_permissions_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package integrationtests
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/mattermost/mattermost-plugin-boards/server/model"
+	"github.com/mattermost/mattermost-plugin-boards/server/utils"
+	mmModel "github.com/mattermost/mattermost/server/public/model"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBoardCreationPermissionEnforcement verifies that the per-type board
+// creation permission (create_public_channel / create_private_channel) is
+// enforced consistently across every board creation endpoint, guarding against
+// a regression where /boards-and-blocks and the archive import endpoints
+// skipped the check (MM-69622).
+func TestBoardCreationPermissionEnforcement(t *testing.T) {
+	t.Run("createBoard honors revoked create permissions", func(t *testing.T) {
+		th := SetupTestHelperPluginMode(t)
+		defer th.TearDown()
+		clients := setupClients(th)
+		th.Client = clients.TeamMember
+
+		teamID := mmModel.NewId()
+		th.PermissionAPI.DenyTeamPermission(userTeamMember, model.PermissionCreatePublicChannel)
+		th.PermissionAPI.DenyTeamPermission(userTeamMember, model.PermissionCreatePrivateChannel)
+
+		_, resp := th.Client.CreateBoard(&model.Board{Title: "public", TeamID: teamID, Type: model.BoardTypeOpen})
+		th.CheckForbidden(resp)
+
+		_, resp = th.Client.CreateBoard(&model.Board{Title: "private", TeamID: teamID, Type: model.BoardTypePrivate})
+		th.CheckForbidden(resp)
+	})
+
+	t.Run("createBoardsAndBlocks honors revoked create permissions", func(t *testing.T) {
+		th := SetupTestHelperPluginMode(t)
+		defer th.TearDown()
+		clients := setupClients(th)
+		th.Client = clients.TeamMember
+
+		teamID := mmModel.NewId()
+
+		// Revoke only the private board permission: creating a private board
+		// must be denied while a public board is still allowed.
+		th.PermissionAPI.DenyTeamPermission(userTeamMember, model.PermissionCreatePrivateChannel)
+
+		_, resp := th.Client.CreateBoardsAndBlocks(newBoardAndBlocks(teamID, model.BoardTypePrivate))
+		th.CheckForbidden(resp)
+
+		bab, resp := th.Client.CreateBoardsAndBlocks(newBoardAndBlocks(teamID, model.BoardTypeOpen))
+		th.CheckOK(resp)
+		require.Len(t, bab.Boards, 1)
+
+		// Revoke the public permission too: now both types are denied.
+		th.PermissionAPI.DenyTeamPermission(userTeamMember, model.PermissionCreatePublicChannel)
+
+		_, resp = th.Client.CreateBoardsAndBlocks(newBoardAndBlocks(teamID, model.BoardTypeOpen))
+		th.CheckForbidden(resp)
+	})
+
+	t.Run("archiveImport honors revoked create permissions", func(t *testing.T) {
+		th := SetupTestHelperPluginMode(t)
+		defer th.TearDown()
+		clients := setupClients(th)
+		th.Client = clients.TeamMember
+
+		teamID := mmModel.NewId()
+
+		// Build a source private board and export it so we have a valid archive.
+		sourceBab, resp := th.Client.CreateBoardsAndBlocks(newBoardAndBlocks(teamID, model.BoardTypePrivate))
+		th.CheckOK(resp)
+		require.Len(t, sourceBab.Boards, 1)
+
+		archive, resp := th.Client.ExportBoardArchive(sourceBab.Boards[0].ID)
+		th.CheckOK(resp)
+		require.NotEmpty(t, archive)
+
+		// Revoke the private board permission and confirm the import is blocked.
+		th.PermissionAPI.DenyTeamPermission(userTeamMember, model.PermissionCreatePrivateChannel)
+
+		resp = th.Client.ImportArchive(teamID, bytes.NewReader(archive))
+		th.CheckForbidden(resp)
+	})
+}
+
+func newBoardAndBlocks(teamID string, boardType model.BoardType) *model.BoardsAndBlocks {
+	boardID := utils.NewID(utils.IDTypeBoard)
+	return &model.BoardsAndBlocks{
+		Boards: []*model.Board{{
+			ID:     boardID,
+			Title:  "Test Board",
+			TeamID: teamID,
+			Type:   boardType,
+		}},
+		Blocks: []*model.Block{{
+			ID:       utils.NewID(utils.IDTypeCard),
+			Title:    "Test Block",
+			BoardID:  boardID,
+			Type:     model.TypeCard,
+			CreateAt: model.GetMillis(),
+			UpdateAt: model.GetMillis(),
+		}},
+	}
+}

--- a/server/integrationtests/clienttestlib.go
+++ b/server/integrationtests/clienttestlib.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -111,10 +112,11 @@ const (
 )
 
 type TestHelper struct {
-	T       *testing.T
-	Server  *server.Server
-	Client  *client.Client
-	Client2 *client.Client
+	T             *testing.T
+	Server        *server.Server
+	Client        *client.Client
+	Client2       *client.Client
+	PermissionAPI *FakePermissionPluginAPI
 
 	origEnvUnitTesting string
 	sqlSettings        *mmModel.SqlSettings
@@ -122,7 +124,31 @@ type TestHelper struct {
 }
 
 type FakePermissionPluginAPI struct {
+	mu          sync.RWMutex
 	emptyTeamID string
+	// deniedTeamPermissions maps a userID to the set of team-level permission IDs
+	// that should be denied for that user, allowing tests to simulate an admin
+	// revoking permissions such as create_public_channel / create_private_channel.
+	deniedTeamPermissions map[string]map[string]bool
+}
+
+// DenyTeamPermission simulates revoking a team-level permission for a user.
+func (f *FakePermissionPluginAPI) DenyTeamPermission(userID string, permission *mmModel.Permission) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.deniedTeamPermissions == nil {
+		f.deniedTeamPermissions = map[string]map[string]bool{}
+	}
+	if f.deniedTeamPermissions[userID] == nil {
+		f.deniedTeamPermissions[userID] = map[string]bool{}
+	}
+	f.deniedTeamPermissions[userID][permission.Id] = true
+}
+
+func (f *FakePermissionPluginAPI) isTeamPermissionDenied(userID string, permission *mmModel.Permission) bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.deniedTeamPermissions[userID][permission.Id]
 }
 
 func (f *FakePermissionPluginAPI) HasPermissionTo(userID string, permission *mmModel.Permission) bool {
@@ -138,6 +164,9 @@ func (f *FakePermissionPluginAPI) HasPermissionToTeam(userID string, teamID stri
 	}
 	// Check against the actual empty team ID from the store, not hardcoded string
 	if teamID == f.emptyTeamID {
+		return false
+	}
+	if f.isTeamPermissionDenied(userID, permission) {
 		return false
 	}
 	return true
@@ -398,6 +427,11 @@ func (t *testServicesAPI) UpdatePreferencesForUser(userID string, preferences mm
 }
 
 func NewTestServerPluginMode(sqlSettings *mmModel.SqlSettings) *server.Server {
+	srv, _ := newTestServerPluginMode(sqlSettings)
+	return srv
+}
+
+func newTestServerPluginMode(sqlSettings *mmModel.SqlSettings) (*server.Server, *FakePermissionPluginAPI) {
 	cfg, err := getTestConfig(sqlSettings)
 	if err != nil {
 		panic(err)
@@ -517,7 +551,7 @@ func NewTestServerPluginMode(sqlSettings *mmModel.SqlSettings) *server.Server {
 		panic(err)
 	}
 
-	return srv
+	return srv, fakePermissionAPI
 }
 
 func SetupTestHelper(t *testing.T) *TestHelper {
@@ -555,7 +589,7 @@ func SetupTestHelperPluginMode(t *testing.T) *TestHelper {
 		}
 	})
 
-	th.Server = NewTestServerPluginMode(sqlSettings)
+	th.Server, th.PermissionAPI = newTestServerPluginMode(sqlSettings)
 	th.Start()
 	return th
 }

--- a/server/model/block.go
+++ b/server/model/block.go
@@ -141,6 +141,11 @@ type BoardModifier func(board *Board, cache map[string]interface{}) bool
 // Return true to import the block or false to skip import.
 type BlockModifier func(block *Block, cache map[string]interface{}) bool
 
+// BoardValidator is a callback invoked for each board during an import to
+// enforce authorization before any board is created. Returning a non-nil
+// error aborts the import.
+type BoardValidator func(board *Board) error
+
 func BlocksFromJSON(data io.Reader) []*Block {
 	var blocks []*Block
 	_ = json.NewDecoder(data).Decode(&blocks)

--- a/server/model/import_export.go
+++ b/server/model/import_export.go
@@ -45,10 +45,11 @@ type ExportArchiveOptions struct {
 
 // ImportArchiveOptions provides options when importing an archive.
 type ImportArchiveOptions struct {
-	TeamID        string
-	ModifiedBy    string
-	BoardModifier BoardModifier
-	BlockModifier BlockModifier
+	TeamID         string
+	ModifiedBy     string
+	BoardModifier  BoardModifier
+	BlockModifier  BlockModifier
+	BoardValidator BoardValidator
 }
 
 // ErrUnsupportedArchiveVersion is an error returned when trying to import an


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR refactors some of the checks done on create boards to make it easy to run the same ones in other flows

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://mattermost.atlassian.net/browse/MM-69622


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: High 🟥

**Regression Risk:** Authorization logic is now centralized and enforced across multiple user-facing board creation paths, including archive import. Archive import adds a new validation pre-pass that requires reader seekability and can abort earlier; this changes failure modes and import control flow (potentially affecting parsing, ordering, and “no partial persistence” behavior).

**QA Recommendation:** Run focused end-to-end permission allow/deny tests across: (1) single board creation, (2) create boards+blocks, and (3) archive import (including multi-board archives and verification that denied boards don’t partially persist). Additionally, manually validate archive import behavior for non-seekable/non-standard inputs to confirm the expected early failure.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->