### PR TITLE
MM-63792: allow duplicating boards with empty file/attachment blocks

### DIFF
--- a/server/app/files.go
+++ b/server/app/files.go
@@ -634,9 +634,9 @@ func (a *App) CopyCardFiles(sourceBoardID string, copiedBlocks []*model.Block, a
 		}
 
 		fileID, isOk := block.Fields["fileId"].(string)
-		if !isOk {
+		if !isOk || fileID == "" {
 			fileID, isOk = block.Fields["attachmentId"].(string)
-			if !isOk {
+			if !isOk || fileID == "" {
 				continue
 			}
 		}

--- a/server/app/files_test.go
+++ b/server/app/files_test.go
@@ -672,17 +672,13 @@ func TestCopyAndUpdateCardFiles(t *testing.T) {
 	})
 
 	t.Run("Empty file ID", func(t *testing.T) {
+		// blocks with an empty fileId/attachmentId should be treated
+		// as having no attached file
 		th.Store.EXPECT().GetBoard(validTestBoardID2).Return(&model.Board{ID: validTestBoardID2, TeamID: "validteam12345678901234567", IsTemplate: false}, nil)
 		mockedFileBackend := &mocks.FileBackend{}
 		th.App.filesBackend = mockedFileBackend
 		err := th.App.CopyAndUpdateCardFiles(validTestBoardID2, "userID", []*model.Block{emptyFileBlock}, false)
-		assert.Error(t, err)
-		if err != nil {
-			assert.True(t,
-				strings.Contains(err.Error(), "Block ID cannot be empty") ||
-					strings.Contains(err.Error(), "Could not validate file ID"),
-				"Expected error message to contain 'Block ID cannot be empty' or 'Could not validate file ID', got: %s", err.Error())
-		}
+		assert.NoError(t, err)
 	})
 }
 

--- a/server/model/block.go
+++ b/server/model/block.go
@@ -187,13 +187,13 @@ func (b *Block) baseValidations() error {
 		return ErrBlockFieldsSizeLimitExceeded
 	}
 
-	if fileID, ok := b.Fields[BlockFieldFileId].(string); ok {
+	if fileID, ok := b.Fields[BlockFieldFileId].(string); ok && fileID != "" {
 		if err = ValidateFileId(fileID); err != nil {
 			return err
 		}
 	}
 
-	if attachmentId, ok := b.Fields[BlockFieldAttachmentId].(string); ok {
+	if attachmentId, ok := b.Fields[BlockFieldAttachmentId].(string); ok && attachmentId != "" {
 		if err = ValidateFileId(attachmentId); err != nil {
 			return err
 		}

--- a/server/model/block_test.go
+++ b/server/model/block_test.go
@@ -609,6 +609,38 @@ func TestBlockIsValid(t *testing.T) {
 		require.ErrorIs(t, err, ErrBlockPropertiesInvalidType)
 	})
 
+	t.Run("Should accept block with empty fileId (no file attached)", func(t *testing.T) {
+		block := &Block{
+			ID:         string(utils.IDTypeNone) + mmModel.NewId(),
+			BoardID:    string(utils.IDTypeNone) + mmModel.NewId(),
+			CreatedBy:  string(utils.IDTypeNone) + mmModel.NewId(),
+			ModifiedBy: string(utils.IDTypeNone) + mmModel.NewId(),
+			Schema:     1,
+			Type:       TypeImage,
+			Title:      "Image with empty fileId",
+			Fields:     map[string]interface{}{BlockFieldFileId: ""},
+			CreateAt:   1234567890,
+			UpdateAt:   1234567890,
+		}
+		require.NoError(t, block.IsValid())
+	})
+
+	t.Run("Should accept block with empty attachmentId (no file attached)", func(t *testing.T) {
+		block := &Block{
+			ID:         string(utils.IDTypeNone) + mmModel.NewId(),
+			BoardID:    string(utils.IDTypeNone) + mmModel.NewId(),
+			CreatedBy:  string(utils.IDTypeNone) + mmModel.NewId(),
+			ModifiedBy: string(utils.IDTypeNone) + mmModel.NewId(),
+			Schema:     1,
+			Type:       TypeAttachment,
+			Title:      "Attachment with empty attachmentId",
+			Fields:     map[string]interface{}{BlockFieldAttachmentId: ""},
+			CreateAt:   1234567890,
+			UpdateAt:   1234567890,
+		}
+		require.NoError(t, block.IsValid())
+	})
+
 	t.Run("Should accept block with properties as map", func(t *testing.T) {
 		block := &Block{
 			ID:         string(utils.IDTypeNone) + mmModel.NewId(),


### PR DESCRIPTION
#### Summary
Duplicating a board failed with `400 Block ID cannot be empty` when any image or attachment block had an empty `fileId` or `attachmentId`. The message came from `ValidateFileId("")` inside `Block.IsValid()` and `CopyCardFiles`aborting the whole duplicate. Fix by treat an empty file reference as "no file attached"

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63792

#### Manual QA
1. Create a board, add a card with an image or attachment element ans upload a file.
2. Remove the file from the element then refresh.
3. Board menu → **Duplicate board**
   - Before: red error duplicate fails.
   - After: `<name> copy` appears in the sidebar and opens.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Changes affect shared block validation and board duplication flows, but behavior is narrowly scoped to empty file references and covered by automated tests.
**QA Recommendation:** Manual QA is recommended for duplicating boards with removed image or attachment files.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->