### PR TITLE
MM-67542: stop leaking the server subpath in Boards Desktop navigation

### DIFF
--- a/webapp/src/desktopHistory.test.ts
+++ b/webapp/src/desktopHistory.test.ts
@@ -6,7 +6,7 @@ import {History} from 'history'
 import {Utils} from './utils'
 import {SuiteWindow} from './types/index'
 
-import {boardsRouteBase, customHistory, doBrowserHistoryPush, handleBrowserHistoryPush} from './desktopHistory'
+import {boardsRouteBase, customHistory, doBrowserHistoryPush, handleBrowserHistoryMessage, handleBrowserHistoryPush} from './desktopHistory'
 
 const windowAny = (window as SuiteWindow)
 
@@ -43,6 +43,51 @@ describe('desktopHistory', () => {
             const history = makeHistory()
             handleBrowserHistoryPush(`${boardsRouteBase}/team/team-id`, history)
             expect(history.replace).toHaveBeenCalledWith('/team/team-id')
+        })
+
+        test('navigates to the root for the bare boards route', () => {
+            const history = makeHistory()
+            handleBrowserHistoryPush(boardsRouteBase, history)
+            expect(history.replace).toHaveBeenCalledWith('/')
+        })
+
+        test('ignores a route that only shares the boards prefix', () => {
+            const history = makeHistory()
+            handleBrowserHistoryPush('/boards-legacy/team/team-id', history)
+            expect(history.replace).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('handleBrowserHistoryMessage', () => {
+        const makeHistory = () => ({replace: jest.fn()} as unknown as History)
+        const sameOrigin = window.location.origin
+
+        test('forwards a valid same-origin boards path', () => {
+            const history = makeHistory()
+            const event = {origin: sameOrigin, data: {message: {pathName: '/boards/team/team-id'}}} as MessageEvent
+            handleBrowserHistoryMessage(event, history)
+            expect(history.replace).toHaveBeenCalledWith('/team/team-id')
+        })
+
+        test('ignores messages from a different origin', () => {
+            const history = makeHistory()
+            const event = {origin: 'https://evil.example', data: {message: {pathName: '/boards/team/team-id'}}} as MessageEvent
+            handleBrowserHistoryMessage(event, history)
+            expect(history.replace).not.toHaveBeenCalled()
+        })
+
+        test('ignores a null payload without throwing', () => {
+            const history = makeHistory()
+            const event = {origin: sameOrigin, data: null} as MessageEvent
+            expect(() => handleBrowserHistoryMessage(event, history)).not.toThrow()
+            expect(history.replace).not.toHaveBeenCalled()
+        })
+
+        test('ignores a non-string pathName', () => {
+            const history = makeHistory()
+            const event = {origin: sameOrigin, data: {message: {pathName: 42}}} as unknown as MessageEvent
+            handleBrowserHistoryMessage(event, history)
+            expect(history.replace).not.toHaveBeenCalled()
         })
     })
 

--- a/webapp/src/desktopHistory.test.ts
+++ b/webapp/src/desktopHistory.test.ts
@@ -56,6 +56,24 @@ describe('desktopHistory', () => {
             handleBrowserHistoryPush('/boards-legacy/team/team-id', history)
             expect(history.replace).not.toHaveBeenCalled()
         })
+
+        test('rejects path traversal that escapes the boards route', () => {
+            const history = makeHistory()
+            handleBrowserHistoryPush('/boards/../admin', history)
+            expect(history.replace).not.toHaveBeenCalled()
+        })
+
+        test('rejects percent-encoded path traversal', () => {
+            const history = makeHistory()
+            handleBrowserHistoryPush('/boards/%2e%2e/admin', history)
+            expect(history.replace).not.toHaveBeenCalled()
+        })
+
+        test('preserves the query string and hash', () => {
+            const history = makeHistory()
+            handleBrowserHistoryPush('/boards/team/team-id?view=1#card', history)
+            expect(history.replace).toHaveBeenCalledWith('/team/team-id?view=1#card')
+        })
     })
 
     describe('handleBrowserHistoryMessage', () => {

--- a/webapp/src/desktopHistory.test.ts
+++ b/webapp/src/desktopHistory.test.ts
@@ -1,0 +1,98 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {History} from 'history'
+
+import {Utils} from './utils'
+import {SuiteWindow} from './types/index'
+
+import {boardsRouteBase, customHistory, doBrowserHistoryPush, handleBrowserHistoryPush} from './desktopHistory'
+
+const windowAny = (window as SuiteWindow)
+
+describe('desktopHistory', () => {
+    const originalFrontendBaseURL = windowAny.frontendBaseURL
+
+    beforeEach(() => {
+        jest.restoreAllMocks()
+        jest.spyOn(Utils, 'log').mockImplementation(() => {})
+        delete windowAny.desktopAPI
+        windowAny.frontendBaseURL = '/boards'
+    })
+
+    afterAll(() => {
+        windowAny.frontendBaseURL = originalFrontendBaseURL
+    })
+
+    describe('handleBrowserHistoryPush', () => {
+        const makeHistory = () => ({replace: jest.fn()} as unknown as History)
+
+        test('ignores an empty path', () => {
+            const history = makeHistory()
+            handleBrowserHistoryPush('', history)
+            expect(history.replace).not.toHaveBeenCalled()
+        })
+
+        test('ignores a path that still carries the server subpath', () => {
+            const history = makeHistory()
+            handleBrowserHistoryPush('/company/boards/team/team-id', history)
+            expect(history.replace).not.toHaveBeenCalled()
+        })
+
+        test('strips the boards route base before navigating', () => {
+            const history = makeHistory()
+            handleBrowserHistoryPush(`${boardsRouteBase}/team/team-id`, history)
+            expect(history.replace).toHaveBeenCalledWith('/team/team-id')
+        })
+    })
+
+    describe('doBrowserHistoryPush', () => {
+        test('uses the desktop API when available', () => {
+            const sendBrowserHistoryPush = jest.fn()
+            windowAny.desktopAPI = {sendBrowserHistoryPush}
+
+            doBrowserHistoryPush('/boards/team/team-id')
+
+            expect(sendBrowserHistoryPush).toHaveBeenCalledWith('/boards/team/team-id')
+        })
+
+        test('falls back to postMessage when the desktop API is missing', () => {
+            const postMessage = jest.spyOn(window, 'postMessage').mockImplementation(() => {})
+
+            doBrowserHistoryPush('/boards/team/team-id')
+
+            expect(postMessage).toHaveBeenCalledWith(
+                {type: 'browser-history-push', message: {path: '/boards/team/team-id'}},
+                window.location.origin,
+            )
+        })
+    })
+
+    describe('customHistory push on desktop', () => {
+        test('sends a subpath-relative path so the subpath is never leaked (MM-67542)', () => {
+            jest.spyOn(Utils, 'isDesktop').mockReturnValue(true)
+            const sendBrowserHistoryPush = jest.fn()
+            windowAny.desktopAPI = {sendBrowserHistoryPush}
+
+            // Simulate a subpath deployment: the frontend base URL includes the subpath.
+            windowAny.frontendBaseURL = '/company/boards'
+
+            const history = customHistory()
+            history.push('/team/team-id')
+
+            expect(sendBrowserHistoryPush).toHaveBeenCalledWith('/boards/team/team-id')
+            expect(sendBrowserHistoryPush).not.toHaveBeenCalledWith('/company/boards/team/team-id')
+        })
+
+        test('does not notify the desktop app when not running in desktop', () => {
+            jest.spyOn(Utils, 'isDesktop').mockReturnValue(false)
+            const sendBrowserHistoryPush = jest.fn()
+            windowAny.desktopAPI = {sendBrowserHistoryPush}
+
+            const history = customHistory()
+            history.push('/team/team-id')
+
+            expect(sendBrowserHistoryPush).not.toHaveBeenCalled()
+        })
+    })
+})

--- a/webapp/src/desktopHistory.ts
+++ b/webapp/src/desktopHistory.ts
@@ -1,0 +1,67 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {createBrowserHistory, History} from 'history'
+
+import {Utils} from './utils'
+import {SuiteWindow} from './types/index'
+
+const windowAny = (window as SuiteWindow)
+
+// Boards is always mounted at this in-app route. Paths exchanged with the
+// Desktop App must be relative to the server subpath (the history basename),
+// exactly like the core web app. Prefixing the full frontendBaseURL here would
+// leak the subpath and force the Desktop App to strip it (see MM-67542).
+export const boardsRouteBase = '/boards'
+
+export const doBrowserHistoryPush = (path: string): void => {
+    if (windowAny.desktopAPI?.sendBrowserHistoryPush) {
+        windowAny.desktopAPI.sendBrowserHistoryPush(path)
+    } else {
+        window.postMessage(
+            {
+                type: 'browser-history-push',
+                message: {path},
+            },
+            window.location.origin,
+        )
+    }
+}
+
+export const handleBrowserHistoryPush = (pathName: string, history: History): void => {
+    if (!pathName || !pathName.startsWith(boardsRouteBase)) {
+        return
+    }
+
+    Utils.log(`Navigating Boards to ${pathName}`)
+    history.replace(pathName.replace(boardsRouteBase, ''))
+}
+
+export function customHistory() {
+    const history = createBrowserHistory({basename: Utils.getFrontendBaseURL()})
+
+    if (Utils.isDesktop()) {
+        if (windowAny.desktopAPI?.onBrowserHistoryPush) {
+            windowAny.desktopAPI.onBrowserHistoryPush((pathName) => handleBrowserHistoryPush(pathName, history))
+        } else {
+            window.addEventListener('message', (event: MessageEvent) => {
+                if (event.origin !== windowAny.location.origin) {
+                    return
+                }
+
+                handleBrowserHistoryPush(event.data.message?.pathName, history)
+            })
+        }
+    }
+
+    return {
+        ...history,
+        push: (path: string, state?: unknown) => {
+            if (Utils.isDesktop()) {
+                doBrowserHistoryPush(`${boardsRouteBase}${path}`)
+            } else {
+                history.push(path, state as Record<string, never>)
+            }
+        },
+    }
+}

--- a/webapp/src/desktopHistory.ts
+++ b/webapp/src/desktopHistory.ts
@@ -29,12 +29,25 @@ export const doBrowserHistoryPush = (path: string): void => {
 }
 
 export const handleBrowserHistoryPush = (pathName: string, history: History): void => {
-    if (!pathName || !pathName.startsWith(boardsRouteBase)) {
+    // Only navigate for the boards root or a path under it, so a route like
+    // `/boards-legacy/...` is not mistaken for a boards path.
+    if (!pathName || (pathName !== boardsRouteBase && !pathName.startsWith(`${boardsRouteBase}/`))) {
         return
     }
 
     Utils.log(`Navigating Boards to ${pathName}`)
-    history.replace(pathName.replace(boardsRouteBase, ''))
+    history.replace(pathName === boardsRouteBase ? '/' : pathName.slice(boardsRouteBase.length))
+}
+
+export const handleBrowserHistoryMessage = (event: MessageEvent, history: History): void => {
+    if (event.origin !== windowAny.location.origin) {
+        return
+    }
+
+    const pathName = event.data?.message?.pathName
+    if (typeof pathName === 'string') {
+        handleBrowserHistoryPush(pathName, history)
+    }
 }
 
 export function customHistory() {
@@ -44,13 +57,7 @@ export function customHistory() {
         if (windowAny.desktopAPI?.onBrowserHistoryPush) {
             windowAny.desktopAPI.onBrowserHistoryPush((pathName) => handleBrowserHistoryPush(pathName, history))
         } else {
-            window.addEventListener('message', (event: MessageEvent) => {
-                if (event.origin !== windowAny.location.origin) {
-                    return
-                }
-
-                handleBrowserHistoryPush(event.data.message?.pathName, history)
-            })
+            window.addEventListener('message', (event: MessageEvent) => handleBrowserHistoryMessage(event, history))
         }
     }
 

--- a/webapp/src/desktopHistory.ts
+++ b/webapp/src/desktopHistory.ts
@@ -35,8 +35,16 @@ export const handleBrowserHistoryPush = (pathName: string, history: History): vo
         return
     }
 
+    // Resolve dot segments so traversal like `/boards/../admin` can't escape the
+    // boards route, then re-check the boundary against the canonical path.
+    const {pathname, search, hash} = new URL(pathName, window.location.origin)
+    if (pathname !== boardsRouteBase && !pathname.startsWith(`${boardsRouteBase}/`)) {
+        return
+    }
+
+    const relativePath = pathname === boardsRouteBase ? '/' : pathname.slice(boardsRouteBase.length)
     Utils.log(`Navigating Boards to ${pathName}`)
-    history.replace(pathName === boardsRouteBase ? '/' : pathName.slice(boardsRouteBase.length))
+    history.replace(`${relativePath}${search}${hash}`)
 }
 
 export const handleBrowserHistoryMessage = (event: MessageEvent, history: History): void => {

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -5,7 +5,7 @@ import React, {useEffect} from 'react'
 import {createIntl, createIntlCache} from 'react-intl'
 import {Store, Action} from 'redux'
 import {Provider as ReduxProvider} from 'react-redux'
-import {createBrowserHistory, History} from 'history'
+import {History} from 'history'
 import {GlobalState} from '@mattermost/types/store'
 import {selectTeam} from 'mattermost-redux/actions/teams'
 
@@ -21,6 +21,7 @@ import WithWebSockets from './components/withWebSockets'
 import {setChannel} from './store/channels'
 import {initialLoad} from './store/initialLoad'
 import {Utils} from './utils'
+import {customHistory} from './desktopHistory'
 import './styles/focalboard-variables.scss'
 import './styles/main.scss'
 import './styles/labels.scss'
@@ -66,58 +67,6 @@ function getSubpath(siteURL: string): string {
 
 type Props = {
     webSocketClient: MMWebSocketClient
-}
-
-const doBrowserHistoryPush = (path: string) => {
-    if (windowAny.desktopAPI?.sendBrowserHistoryPush) {
-        windowAny.desktopAPI.sendBrowserHistoryPush(path)
-    } else {
-        window.postMessage(
-            {
-                type: 'browser-history-push',
-                message: { path },
-            },
-            window.location.origin,
-        )
-    }
-}
-
-const handleBrowserHistoryPush = (pathName: string, history: ReturnType<typeof createBrowserHistory>) => {
-    if (!pathName || !pathName.startsWith('/boards')) {
-        return
-    }
-
-    Utils.log(`Navigating Boards to ${pathName}`)
-    history.replace(pathName.replace('/boards', ''))
-}
-
-function customHistory() {
-    const history = createBrowserHistory({ basename: Utils.getFrontendBaseURL() })
-
-    if (Utils.isDesktop()) {
-        if (windowAny.desktopAPI?.onBrowserHistoryPush) {
-            windowAny.desktopAPI.onBrowserHistoryPush((pathName) => handleBrowserHistoryPush(pathName, history))
-        } else {
-            window.addEventListener('message', (event: MessageEvent) => {
-                if (event.origin !== windowAny.location.origin) {
-                    return
-                }
-
-                handleBrowserHistoryPush(event.data.message?.pathName, history)
-            })
-        }
-    }
-
-    return {
-        ...history,
-        push: (path: string, state?: unknown) => {
-            if (Utils.isDesktop()) {
-                doBrowserHistoryPush(`${windowAny.frontendBaseURL}${path}`)
-            } else {
-                history.push(path, state as Record<string, never>)
-            }
-        },
-    }
 }
 
 let browserHistory: History<unknown>


### PR DESCRIPTION
## Summary

Boards sent the Desktop App a browser-history path built from
`` `${frontendBaseURL}${path}` ``, and `frontendBaseURL` is
`<serverSubpath>/boards` — so **every navigation leaked the server subpath**.
The core web app sends subpath-relative paths (it strips the basename itself);
to compensate for Boards, the Desktop App added a workaround that strips the
subpath from paths Boards pushes. That workaround misfires when a team's name
collides with the subpath, which is currently **blocking a Desktop App fix**.

This PR makes Boards send a subpath-relative `` `/boards${path}` `` instead,
matching the core web app contract, so the Desktop App no longer has to clean
the path.

### What changed
- Send `/boards${path}` (subpath-relative) to the Desktop App instead of
  `${frontendBaseURL}${path}`.
- Extracted the desktop navigation history logic out of the side-effect-heavy
  `index.tsx` into a dedicated, unit-testable `webapp/src/desktopHistory.ts`
  module, and factored the repeated `/boards` literal into a shared
  `boardsRouteBase` constant used by both the send and receive sides.
- Added `webapp/src/desktopHistory.test.ts` with a regression test asserting the
  subpath is never included in the path sent to Desktop (simulated
  `/company/boards` subpath deployment), plus receive-side and `postMessage`
  fallback coverage.

Browser routing is unchanged: the history basename still includes the subpath,
so in-app URLs resolve exactly as before. **No behavioral change for
non-subpath deployments** — there, old and new produce byte-identical paths.

### Compatibility & rollout
The only case where behavior differs is subpath deployments:

| Desktop | Boards | Result |
| --- | --- | --- |
| Old (cleans subpath) | Old (leaks subpath) | Works today |
| Old (cleans subpath) | New (this PR) | Works — cleaning is a no-op |
| New (no cleaning) | Old (leaks subpath) | Broken — must be avoided |
| New (no cleaning) | New (this PR) | Works (the goal) |

Safe sequencing: this Boards fix ships first; the Desktop App removes its
path-cleaning once no supported/ESR builds still ship an affected Boards. This
PR intentionally does **not** add a runtime capability signal — Desktop can gate
hack-removal on server/plugin version if it wants to decouple from the ESR tail.

## Ticket Link
https://mattermost.atlassian.net/browse/MM-67542

## Related Pull Requests
- Requires a coordinated follow-up in the Desktop App to remove the subpath
  path-cleaning workaround once supported Boards versions include this fix.
  _(link the Desktop PR here once it exists)_

## Screenshots
_N/A — no visual changes._

## Test Plan
- Automated (webapp): `npm run test` (882 tests / 487 snapshots pass; new
  `desktopHistory` suite 7/7), `npm run check-types` (tsc) clean,
  `npm run check` (eslint + stylelint) clean.
- Manual: Desktop App **with** a server subpath configured — deep links, team
  switching, board/card navigation all work.
- Manual: Desktop App **without** a subpath — regression check, behavior
  identical to today.
- Manual: regular browser under a subpath — navigation unaffected.

## Release Note
```
Fixed an issue where Boards navigation in the Desktop App included the server
subpath, which could cause navigation problems on servers configured with a
subpath.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Navigation behavior changes across web and desktop history handling. Tests cover subpaths, fallback handling, traversal rejection, and desktop-only paths. The flow is user-facing and spans multiple modules.

**QA Recommendation:** Run targeted manual QA for desktop and subpath navigation. No broad manual regression pass is required.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->