### PR TITLE
MM-64344: fix intermittent LHS board drag-and-drop ordering

### DIFF
--- a/webapp/src/components/sidebar/sidebar.tsx
+++ b/webapp/src/components/sidebar/sidebar.tsx
@@ -20,6 +20,7 @@ import './sidebar.scss'
 import {
     BoardCategoryWebsocketData,
     Category,
+    CategoryBoardMetadata,
     CategoryBoards,
     fetchSidebarCategories,
     getSidebarCategories,
@@ -201,6 +202,33 @@ const Sidebar = (props: Props) => {
         await octoClient.reorderSidebarCategories(team.id, newCategoryOrder)
     }, [team, sidebarCategories])
 
+    const getVisibleBoardIDs = useCallback((category: CategoryBoards): string[] => {
+        const boardsByID = new Map(boards.map((board) => [board.id, board]))
+
+        return category.boardMetadata.
+            filter((boardMetadata) => {
+                if (boardMetadata.hidden) {
+                    return false
+                }
+                const board = boardsByID.get(boardMetadata.boardID)
+                return Boolean(board) && !board!.isTemplate
+            }).
+            map((boardMetadata) => boardMetadata.boardID)
+    }, [boards])
+
+    const getMetadataInsertIndex = (boardsMetadata: CategoryBoardMetadata[], visibleBoardIDs: string[], visibleIndex: number): number => {
+        if (visibleBoardIDs.length === 0) {
+            return boardsMetadata.length
+        }
+
+        if (visibleIndex >= visibleBoardIDs.length) {
+            const lastVisibleID = visibleBoardIDs[visibleBoardIDs.length - 1]
+            return boardsMetadata.findIndex((boardMetadata) => boardMetadata.boardID === lastVisibleID) + 1
+        }
+
+        return boardsMetadata.findIndex((boardMetadata) => boardMetadata.boardID === visibleBoardIDs[visibleIndex])
+    }
+
     const handleCategoryBoardDND = useCallback(async (result: DropResult) => {
         const {source, destination, draggableId} = result
 
@@ -221,8 +249,16 @@ const Sidebar = (props: Props) => {
 
         if (fromCategoryID === toCategoryID) {
             const categoryBoardMetadata = [...toSidebarCategory.boardMetadata]
-            categoryBoardMetadata.splice(source.index, 1)
-            categoryBoardMetadata.splice(destination.index, 0, toSidebarCategory.boardMetadata[source.index])
+            const sourceMetadataIndex = categoryBoardMetadata.findIndex((boardMetadata) => boardMetadata.boardID === boardID)
+            if (sourceMetadataIndex < 0) {
+                Utils.logError(`dragged board not found in category metadata. boardID: ${boardID}, categoryID: ${toCategoryID}`)
+                return
+            }
+
+            const [movedBoardMetadata] = categoryBoardMetadata.splice(sourceMetadataIndex, 1)
+            const remainingVisibleBoardIDs = getVisibleBoardIDs(toSidebarCategory).filter((id) => id !== boardID)
+            const insertIndex = getMetadataInsertIndex(categoryBoardMetadata, remainingVisibleBoardIDs, destination.index)
+            categoryBoardMetadata.splice(insertIndex, 0, movedBoardMetadata)
 
             dispatch(updateCategoryBoardsOrder({categoryID: toCategoryID, boardsMetadata: categoryBoardMetadata}))
 
@@ -241,9 +277,15 @@ const Sidebar = (props: Props) => {
                 return
             }
 
+            const fromCategoryBoardMetadata = fromSidebarCategory.boardMetadata.find((boardMetadata) => boardMetadata.boardID === boardID)
+            if (!fromCategoryBoardMetadata) {
+                Utils.logError(`dragged board not found in source category metadata. boardID: ${boardID}, categoryID: ${fromCategoryID}`)
+                return
+            }
+
             const categoryBoardMetadata = [...toSidebarCategory.boardMetadata]
-            const fromCategoryBoardMetadata = fromSidebarCategory.boardMetadata[source.index]
-            categoryBoardMetadata.splice(destination.index, 0, fromCategoryBoardMetadata)
+            const insertIndex = getMetadataInsertIndex(categoryBoardMetadata, getVisibleBoardIDs(toSidebarCategory), destination.index)
+            categoryBoardMetadata.splice(insertIndex, 0, fromCategoryBoardMetadata)
 
             await dispatch(updateCategoryBoardsOrder({categoryID: toCategoryID, boardsMetadata: categoryBoardMetadata}))
             dispatch(updateBoardCategories([{...fromCategoryBoardMetadata, categoryID: toCategoryID}]))
@@ -266,7 +308,7 @@ const Sidebar = (props: Props) => {
                 dispatch(updateCategoryBoardsOrder({categoryID: toCategoryID, boardsMetadata: previousToBoardsMetadata}))
             }
         }
-    }, [team, sidebarCategories])
+    }, [team, sidebarCategories, getVisibleBoardIDs])
 
     const onDragEnd = useCallback(async (result: DropResult) => {
         const {destination, source, type} = result

--- a/webapp/src/components/sidebar/sidebar.tsx
+++ b/webapp/src/components/sidebar/sidebar.tsx
@@ -335,7 +335,7 @@ const Sidebar = (props: Props) => {
 
         setDraggedItemID('')
         setIsCategoryBeingDragged(false)
-    }, [team, sidebarCategories])
+    }, [team, sidebarCategories, handleCategoryDND, handleCategoryBoardDND])
 
     const [draggedItemID, setDraggedItemID] = useState<string>('')
     const [isCategoryBeingDragged, setIsCategoryBeingDragged] = useState<boolean>(false)

--- a/webapp/src/components/sidebar/sidebarDragAndDrop.test.tsx
+++ b/webapp/src/components/sidebar/sidebarDragAndDrop.test.tsx
@@ -1,0 +1,179 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react'
+import configureStore from 'redux-mock-store'
+
+import {createMemoryHistory} from 'history'
+import {Provider as ReduxProvider} from 'react-redux'
+import {Router} from 'react-router-dom'
+
+import {render, waitFor} from '@testing-library/react'
+
+import thunk from 'redux-thunk'
+
+import {mocked} from 'jest-mock'
+
+import {DropResult} from 'react-beautiful-dnd'
+
+import {mockMatchMedia, wrapIntl} from '../../testUtils'
+
+import {TestBlockFactory} from '../../test/testBlockFactory'
+import octoClient from '../../octoClient'
+
+import Sidebar from './sidebar'
+
+const mockDnd: {onDragEnd?: (result: DropResult) => void} = {}
+
+type MockRenderChildren = {
+    children: (provided: unknown, snapshot: unknown) => React.ReactNode
+}
+
+jest.mock('react-beautiful-dnd', () => {
+    const react = jest.requireActual('react')
+
+    return {
+        DragDropContext: (props: {onDragEnd: (result: DropResult) => void, children: React.ReactNode}) => {
+            mockDnd.onDragEnd = props.onDragEnd
+            return react.createElement(react.Fragment, null, props.children)
+        },
+        Droppable: (props: MockRenderChildren) => props.children(
+            {innerRef: () => null, droppableProps: {}, placeholder: null},
+            {isDraggingOver: false},
+        ),
+        Draggable: (props: MockRenderChildren) => props.children(
+            {innerRef: () => null, draggableProps: {}, dragHandleProps: {}},
+            {isDragging: false},
+        ),
+    }
+})
+
+jest.mock('../../octoClient')
+const mockedOctoClient = mocked(octoClient, true)
+
+beforeAll(() => {
+    mockMatchMedia({matches: true})
+})
+
+describe('components/sidebar drag and drop ordering', () => {
+    const mockStore = configureStore([thunk])
+
+    const makeBoard = (id: string, title: string) => {
+        const board = TestBlockFactory.createBoard()
+        board.id = id
+        board.title = title
+        return board
+    }
+
+    const hiddenBoard = makeBoard('hidden_board', 'Hidden board')
+    const board1 = makeBoard('board1', 'Board 1')
+    const board2 = makeBoard('board2', 'Board 2')
+    const board3 = makeBoard('board3', 'Board 3')
+
+    const allBoards = [hiddenBoard, board1, board2, board3]
+
+    const buildStore = () => {
+        const category = TestBlockFactory.createCategoryBoards()
+        category.id = 'category1'
+        category.name = 'Category 1'
+        category.boardMetadata = [
+            {boardID: hiddenBoard.id, hidden: true},
+            {boardID: board1.id, hidden: false},
+            {boardID: board2.id, hidden: false},
+            {boardID: board3.id, hidden: false},
+        ]
+
+        const boardsByID: Record<string, unknown> = {}
+        allBoards.forEach((board) => {
+            boardsByID[board.id] = board
+        })
+
+        return mockStore({
+            teams: {
+                current: {id: 'team-id'},
+            },
+            boards: {
+                current: board1.id,
+                boards: boardsByID,
+                myBoardMemberships: boardsByID,
+            },
+            cards: {
+                cards: {},
+                current: '',
+            },
+            views: {
+                views: [],
+            },
+            users: {
+                me: {
+                    id: 'user_id_1',
+                    props: {},
+                },
+            },
+            sidebar: {
+                categoryAttributes: [category],
+                hiddenBoardIDs: [],
+            },
+        })
+    }
+
+    const renderSidebar = () => {
+        const history = createMemoryHistory()
+
+        return render(wrapIntl(
+            <ReduxProvider store={buildStore()}>
+                <Router history={history}>
+                    <Sidebar onBoardTemplateSelectorOpen={jest.fn()}/>
+                </Router>
+            </ReduxProvider>,
+        ))
+    }
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockDnd.onDragEnd = undefined
+        mockedOctoClient.reorderSidebarCategoryBoards.mockResolvedValue([])
+    })
+
+    test('renders only visible boards as draggables', () => {
+        const {container} = renderSidebar()
+
+        const sidebarBoards = container.getElementsByClassName('SidebarBoardItem')
+        expect(sidebarBoards.length).toBe(3)
+    })
+
+    test('reorders the dragged board when the category contains a hidden board', async () => {
+        renderSidebar()
+        expect(mockDnd.onDragEnd).toBeDefined()
+
+        mockDnd.onDragEnd!({
+            type: 'board',
+            draggableId: board3.id,
+            source: {droppableId: 'category1', index: 2},
+            destination: {droppableId: 'category1', index: 0},
+        } as DropResult)
+
+        await waitFor(() => expect(mockedOctoClient.reorderSidebarCategoryBoards).toBeCalledWith(
+            'team-id',
+            'category1',
+            [hiddenBoard.id, board3.id, board1.id, board2.id],
+        ))
+    })
+
+    test('reorders to the end of the category without dropping any board', async () => {
+        renderSidebar()
+
+        mockDnd.onDragEnd!({
+            type: 'board',
+            draggableId: board1.id,
+            source: {droppableId: 'category1', index: 0},
+            destination: {droppableId: 'category1', index: 2},
+        } as DropResult)
+
+        await waitFor(() => expect(mockedOctoClient.reorderSidebarCategoryBoards).toBeCalledWith(
+            'team-id',
+            'category1',
+            [hiddenBoard.id, board2.id, board3.id, board1.id],
+        ))
+    })
+})


### PR DESCRIPTION
#### Summary
The sidebar renders only visible no template boards as draggables but `handleCategoryBoardDND` applied to the unfiltered `boardMetadata` array which also contains hidden boards. Any such entry sitting before the dragged board moved the wrong board and the drag appeared to do nothing.

This is why the bug looks random and mostly hits older installs since categories only diverge once they contain a hidden board and migration `000037_hidden_boards_from_preferences` backfilled hidden flags onto long lived accounts.

#### Test
New `sidebarDragAndDrop.test.tsx` mocks react-beautiful-dnd to fire synthetic drops against a category containing a hidden board. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** Changes are isolated to sidebar drag-and-drop ordering. Targeted automated tests cover hidden-board scenarios. No public APIs or shared utilities change.

**QA Recommendation:** Manual QA can be skipped. Automated test coverage is sufficient.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->